### PR TITLE
feat(authenticator): Remove field hiding from the FormState

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/forms/FormState.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/forms/FormState.kt
@@ -37,11 +37,6 @@ interface FormState {
      * Flag indicating whether the form is currently being submitted.
      */
     val submitting: Boolean
-
-    /**
-     * Flag indicating whether sensitive fields such as passwords are hidden from the user.
-     */
-    val fieldsHidden: Boolean
 }
 
 /**
@@ -55,11 +50,6 @@ interface MutableFormState : FormState {
      * holding configuration options and mutable state for the field.
      */
     override val fields: Map<FieldKey, MutableFieldData>
-
-    /**
-     * Toggle the visibility of hidden fields (e.g. passwords) within the form.
-     */
-    fun toggleHiddenFields()
 }
 
 /**
@@ -102,8 +92,6 @@ internal class FormStateImpl : MutableFormState {
 
     override var submitting by mutableStateOf(false)
 
-    override var fieldsHidden by mutableStateOf(true)
-
     private var onSubmit: suspend () -> Unit = {}
 
     fun add(config: FieldConfig) {
@@ -131,10 +119,6 @@ internal class FormStateImpl : MutableFormState {
 
     fun getContent(key: FieldKey): String? {
         return fields[key]?.state?.content
-    }
-
-    override fun toggleHiddenFields() {
-        fieldsHidden = !fieldsHidden
     }
 
     suspend fun submit() {

--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/ui/AuthenticatorField.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/ui/AuthenticatorField.kt
@@ -22,6 +22,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.amplifyframework.ui.authenticator.forms.FieldConfig
 import com.amplifyframework.ui.authenticator.forms.FieldError
@@ -45,14 +49,17 @@ internal fun AuthenticatorField(
             fieldState = fieldState,
             enabled = !formState.submitting
         )
-        is FieldConfig.Password -> PasswordInputField(
-            modifier = modifier,
-            fieldConfig = fieldConfig,
-            fieldState = fieldState,
-            enabled = !formState.submitting,
-            hidden = formState.fieldsHidden,
-            onClickHideShow = { formState.toggleHiddenFields() }
-        )
+        is FieldConfig.Password -> {
+            var hidden by remember { mutableStateOf(true) }
+            PasswordInputField(
+                modifier = modifier,
+                fieldConfig = fieldConfig,
+                fieldState = fieldState,
+                hidden = hidden,
+                onClickHideShow = { hidden = !hidden },
+                enabled = !formState.submitting
+            )
+        }
         is FieldConfig.Date -> DateInputField(
             modifier = modifier,
             fieldConfig = fieldConfig,


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
- Field hide/show is not controlled by the formState instance.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
