### PR TITLE
fix(authenticator): Make onDisplayMessage not a suspending function

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/ui/Authenticator.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/ui/Authenticator.kt
@@ -97,7 +97,7 @@ fun Authenticator(
     errorContent: @Composable (state: ErrorState) -> Unit = { AuthenticatorError(it) },
     headerContent: @Composable () -> Unit = {},
     footerContent: @Composable () -> Unit = {},
-    onDisplayMessage: (suspend (AuthenticatorMessage) -> Unit)? = null,
+    onDisplayMessage: ((AuthenticatorMessage) -> Unit)? = null,
     content: @Composable (state: SignedInState) -> Unit
 ) {
     val snackbarState = remember { SnackbarHostState() }


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
n/a

*Description of changes:*
- onDisplayMessage should not be a suspending function. Although a callback from a coroutine context, it is not idiomatic to have it be a suspending function since the invoking context is scoped to the Authenticator composable. Instead, consumer should launch a new coroutine in their desired scope.

*How did you test these changes?*
n/a

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
