### PR TITLE
fix(authenticator): Rename AuthenticatorMessage.Information to AuthenticatorMessage.Info

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/util/AuthenticatorMessage.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/util/AuthenticatorMessage.kt
@@ -39,7 +39,7 @@ interface AuthenticatorMessage {
     /**
      * Indicates an informational update for the user, such as the successful completion of an async process.
      */
-    interface Information : AuthenticatorMessage
+    interface Info : AuthenticatorMessage
 
     /**
      * Indicates an error occurred. You may inspect the [cause] for more information.
@@ -71,14 +71,14 @@ internal abstract class AuthenticatorMessageImpl(
  */
 internal object PasswordResetMessage :
     AuthenticatorMessageImpl(R.string.amplify_ui_authenticator_message_password_reset),
-    AuthenticatorMessage.Information
+    AuthenticatorMessage.Info
 
 /**
  * A confirmation code was sent to the user.
  */
 internal object CodeSentMessage :
     AuthenticatorMessageImpl(R.string.amplify_ui_authenticator_message_code_sent),
-    AuthenticatorMessage.Information
+    AuthenticatorMessage.Info
 
 /**
  * The user cannot reset their password because their account is in an invalid state.


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
- Rename `Information` to `Info` to match the Swift naming.

*How did you test these changes?*

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
