### PR TITLE
fix(liveness): check for empty session ID

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -98,6 +98,17 @@ fun FaceLivenessDetector(
         return
     }
 
+    // fails challenge if session ID is empty
+    if (sessionId.isBlank()) {
+        LaunchedEffect(key) {
+            isFinished = true
+            currentOnError.accept(
+                FaceLivenessDetectionException.SessionNotFoundException("Session ID cannot be empty.")
+            )
+        }
+        return
+    }
+
     // Locks portrait orientation for duration of challenge and resets on complete
     LockPortraitOrientation()
 


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:* Check for an empty session ID at the beginning of the liveness flow before starting the liveness challenge.

*How did you test these changes?*
Tested in the liveness sample app.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
