### PR TITLE
fix(liveness): Use server facematch timeout

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/LivenessCoordinator.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/LivenessCoordinator.kt
@@ -294,7 +294,6 @@ internal class LivenessCoordinator(
         const val TARGET_ENCODE_BITRATE = (1024 * 1024 * .6).toInt()
         const val TARGET_ENCODE_KEYFRAME_INTERVAL = 1 // webm muxer only flushes to file on keyframe
         val TARGET_RESOLUTION_SIZE = Size(TARGET_WIDTH, TARGET_HEIGHT)
-        const val FACE_OVAL_MATCH_TIMEOUT_MS: Long = 7000
         const val DISCONNECT_EVENT_TIMEOUT_MS: Long = 8000
     }
 }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
@@ -263,7 +263,7 @@ internal data class LivenessState(
             // the oval after a period of time
             if (!detectedFaceMatchedOval && !faceOvalMatchTimerStarted) {
                 faceOvalMatchTimerStarted = true
-                Timer().schedule(LivenessCoordinator.FACE_OVAL_MATCH_TIMEOUT_MS) {
+                Timer().schedule(faceTargetChallenge!!.faceTargetMatching.ovalFitTimeout.toLong()) {
                     if (!detectedFaceMatchedOval && faceGuideRect != null) {
                         readyForOval = false
                         val timeoutError =

--- a/liveness/src/main/res/values/strings.xml
+++ b/liveness/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="amplify_ui_liveness_get_ready_a11y_wrong_face_fit_icon_content_description">Face does not fill the oval</string>
     <string name="amplify_ui_liveness_get_ready_good_fit">Good fit</string>
     <string name="amplify_ui_liveness_get_ready_too_far">Too far</string>
-    <string name="amplify_ui_liveness_get_ready_step_1">When an oval appears, fill the oval with your face within 7 seconds.</string>
+    <string name="amplify_ui_liveness_get_ready_step_1">When an oval appears, follow the instructions to fit your face in it.</string>
     <string name="amplify_ui_liveness_get_ready_step_2">Make sure your face is not covered with sunglasses or a mask.</string>
     <string name="amplify_ui_liveness_get_ready_step_3">Move to a well-lit place that is not in direct sunlight.</string>
     <string name="amplify_ui_liveness_get_ready_begin_check">Begin check</string>

--- a/samples/liveness/app/src/main/res/values/strings.xml
+++ b/samples/liveness/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="error_camera_permission_denied_title">Camera permission not granted</string>
     <string name="error_camera_permission_denied_message">Camera permission required to perform check</string>
     <string name="error_timed_out_title">Time out</string>
-    <string name="error_timed_out_face_fit_message">Face did not fill oval within time limit. Try again and completely fill oval with face within 7 seconds.</string>
+    <string name="error_timed_out_face_fit_message">Face did not fill oval within time limit. Try again and completely fill oval with face within it.</string>
     <string name="error_timed_out_session_message">Session timed out. Try again.</string>
     <string name="error_failure_during_countdown_title">"Check failed during countdown"</string>
     <string name="error_failure_during_countdown_message">Avoid moving closer during countdown and ensure only one face is in front of camera.</string>


### PR DESCRIPTION
REQUIRES AMPLIFY VERSION BUMP AFTER [AMPLIFY PR](https://github.com/aws-amplify/amplify-android/pull/2577) IS RELEASED

- [ ] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
Read facematch timeout from server -- should be attached to the event we get back from Amplify.  Also remove all wording of 7 second fixed timeout.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
