### PR TITLE
chore: (assuming Amplify version is 2.13.1) Amplify version bump

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.0.0"
-amplify = "2.11.1"
+amplify = "2.13.1"
 cameraX = "1.2.0"
 compose = "1.3.2"
 dokka = "1.8.10"

--- a/samples/liveness/build.gradle
+++ b/samples/liveness/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         compose_version = '1.3.3'
-        amplifyVersion = '2.11.1'
+        amplifyVersion = '2.13.1'
         amplifyUIVersion = '1.1.2'
     }
     repositories {


### PR DESCRIPTION
Just to make oncall's life easier -- this PR should be merged after the Amplify ones.  Then, we can rebase this repo's liveness PRs and the tests should be able to run.  The version bump of the sample app is very important, I didn't want to miss it.

- [ ] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
