### PR TITLE
fix(Authenticator): Add error messages when a TOTP next step is received

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -85,8 +85,12 @@ import org.jetbrains.annotations.VisibleForTesting
 
 internal class AuthenticatorViewModel(
     application: Application,
-    private val authProvider: AuthProvider = RealAuthProvider()
+    private val authProvider: AuthProvider
 ) : AndroidViewModel(application) {
+
+    // Constructor for compose viewModels provider
+    constructor(application: Application) : this(application, RealAuthProvider())
+
     private val logger = Amplify.Logging.forNamespace("Authenticator")
 
     private lateinit var authConfiguration: AmplifyAuthConfiguration

--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -81,13 +81,12 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.VisibleForTesting
 
-internal class AuthenticatorViewModel(application: Application) : AndroidViewModel(application) {
-
-    companion object {
-        var authProvider: AuthProvider = RealAuthProvider()
-    }
-
+internal class AuthenticatorViewModel(
+    application: Application,
+    private val authProvider: AuthProvider = RealAuthProvider()
+) : AndroidViewModel(application) {
     private val logger = Amplify.Logging.forNamespace("Authenticator")
 
     private lateinit var authConfiguration: AmplifyAuthConfiguration
@@ -102,7 +101,7 @@ internal class AuthenticatorViewModel(application: Application) : AndroidViewMod
         get() = stepState.value
 
     // Gets the current state or null if the current state is not the parameter type
-    private inline fun <reified T> getState(): T? = currentState as? T
+    private inline fun <reified T> currentStateAs(): T? = currentState as? T
 
     private val _events = MutableSharedFlow<AuthenticatorMessage>(
         extraBufferCapacity = 1,
@@ -230,7 +229,8 @@ internal class AuthenticatorViewModel(application: Application) : AndroidViewMod
     //endregion
     //region SignIn
 
-    private suspend fun signIn(username: String, password: String) {
+    @VisibleForTesting
+    suspend fun signIn(username: String, password: String) {
         viewModelScope.launch {
             when (val result = authProvider.signIn(username, password)) {
                 is AmplifyResult.Error -> handleSignInFailure(username, password, result.error)
@@ -292,7 +292,7 @@ internal class AuthenticatorViewModel(application: Application) : AndroidViewMod
     }
 
     private suspend fun handleSignInSuccess(username: String, password: String, result: AuthSignInResult) {
-        when (result.nextStep.signInStep) {
+        when (val nextStep = result.nextStep.signInStep) {
             AuthSignInStep.DONE -> checkVerificationMechanisms()
             AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE -> moveTo(
                 stateFactory.newSignInMfaState(
@@ -316,6 +316,26 @@ internal class AuthenticatorViewModel(application: Application) : AndroidViewMod
             // This step isn't actually returned, it comes back as a UserNotConfirmedException.
             // Handling here for future correctness
             AuthSignInStep.CONFIRM_SIGN_UP -> handleUnconfirmedSignIn(username, password)
+            // Show an error for TOTP next step
+            AuthSignInStep.CONTINUE_SIGN_IN_WITH_TOTP_SETUP,
+            AuthSignInStep.CONTINUE_SIGN_IN_WITH_MFA_SELECTION,
+            AuthSignInStep.CONFIRM_SIGN_IN_WITH_TOTP_CODE -> {
+                val exception = AuthException(
+                    "Authenticator does not yet support TOTP workflows.",
+                    "Disable TOTP to use Authenticator."
+                )
+                logger.error("Unsupported next step $nextStep", exception)
+                sendMessage(UnknownErrorMessage(exception))
+            }
+            else -> {
+                // Generic error for any other next steps that may be added in the future
+                val exception = AuthException(
+                    "Unsupported next step $nextStep.",
+                    "Authenticator does not support this Authentication flow, disable it to use Authenticator."
+                )
+                logger.error("Unsupported next step $nextStep", exception)
+                sendMessage(UnknownErrorMessage(exception))
+            }
         }
     }
 
@@ -463,7 +483,7 @@ internal class AuthenticatorViewModel(application: Application) : AndroidViewMod
 
     private suspend fun handleAuthException(error: AuthException) {
         logger.warn("Encountered AuthException: $error")
-        val state = getState<BaseStateImpl>() ?: return
+        val state = currentStateAs<BaseStateImpl>() ?: return
         when (error) {
             is InvalidParameterException -> {
                 // TODO : This happens if a field is invalid format e.g. phone number

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorMatchers.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorMatchers.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.ui.authenticator
+
+import com.amplifyframework.ui.authenticator.util.AuthenticatorMessage
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+fun haveMessage(expected: String) = Matcher<AuthenticatorMessage.Error> {
+    MatcherResult(
+        it.cause.message == expected,
+        { "error has message of ${it.cause.message} but it should have message $expected" },
+        { "error should not have message $expected" }
+    )
+}
+
+fun haveRecoverySuggestion(expected: String) = Matcher<AuthenticatorMessage.Error> {
+    MatcherResult(
+        it.cause.recoverySuggestion == expected,
+        { "error has message of ${it.cause.recoverySuggestion} but it should have message $expected" },
+        { "error should not have message $expected" }
+    )
+}
+
+fun AuthenticatorMessage?.shouldBeError(
+    causeMessage: String? = null,
+    recoverySuggestion: String? = null
+) {
+    val casted = this.shouldBeInstanceOf<AuthenticatorMessage.Error>()
+    causeMessage?.let { casted should haveMessage(it) }
+    recoverySuggestion?.let { casted should haveRecoverySuggestion(it) }
+}

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.ui.authenticator
+
+import android.app.Application
+import app.cash.turbine.test
+import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.ui.authenticator.enums.AuthenticatorStep
+import com.amplifyframework.ui.authenticator.util.AmplifyResult
+import com.amplifyframework.ui.authenticator.util.AuthProvider
+import com.amplifyframework.ui.testing.CoroutineTestRule
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Unit tests for the [AuthenticatorViewModel] class
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthenticatorViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val application = mockk<Application>(relaxed = true)
+    private val authProvider = mockk<AuthProvider>(relaxed = true)
+
+    private val viewModel = AuthenticatorViewModel(application, authProvider)
+
+//region start tests
+
+    @Test
+    fun `start only executes once`() = runTest {
+        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthConfiguration())
+        advanceUntilIdle()
+
+        // fetchAuthSession only called by the first start
+        coVerify(exactly = 1) {
+            authProvider.fetchAuthSession()
+        }
+    }
+
+    @Test
+    fun `missing configuration results in an error`() = runTest {
+        coEvery { authProvider.getConfiguration() } returns null
+
+        viewModel.start(mockAuthConfiguration())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { authProvider.fetchAuthSession() }
+        viewModel.currentStep shouldBe AuthenticatorStep.Error
+    }
+
+    @Test
+    fun `fetchAuthSession error during start results in an error`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Error(mockAuthException())
+
+        viewModel.start(mockAuthConfiguration())
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { authProvider.fetchAuthSession() }
+        viewModel.currentStep shouldBe AuthenticatorStep.Error
+    }
+
+    @Test
+    fun `getCurrentUser error during start results in an error`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = true))
+        coEvery { authProvider.getCurrentUser() } returns AmplifyResult.Error(mockAuthException())
+
+        viewModel.start(mockAuthConfiguration())
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            authProvider.fetchAuthSession()
+            authProvider.getCurrentUser()
+        }
+        viewModel.currentStep shouldBe AuthenticatorStep.Error
+    }
+
+    @Test
+    fun `when already signed in during start the initial state should be signed in`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = true))
+        coEvery { authProvider.getCurrentUser() } returns AmplifyResult.Success(mockAuthUser())
+
+        viewModel.start(mockAuthConfiguration())
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            authProvider.fetchAuthSession()
+            authProvider.getCurrentUser()
+        }
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
+    }
+
+    @Test
+    fun `initial step is SignIn`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
+
+        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        advanceUntilIdle()
+
+        viewModel.currentStep shouldBe AuthenticatorStep.SignIn
+    }
+
+//endregion
+//region signIn tests
+
+    @Test
+    fun `TOTPSetup next step is unsupported`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_TOTP_SETUP)
+        )
+
+        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.events.test {
+            viewModel.signIn("username", "password")
+            awaitItem().shouldBeError(causeMessage = "Authenticator does not yet support TOTP workflows.")
+        }
+    }
+
+    @Test
+    fun `TOTP Code next step is unsupported`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_IN_WITH_TOTP_CODE)
+        )
+
+        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.events.test {
+            viewModel.signIn("username", "password")
+            awaitItem().shouldBeError(causeMessage = "Authenticator does not yet support TOTP workflows.")
+        }
+    }
+
+    @Test
+    fun `MFA Selection next step is unsupported`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_MFA_SELECTION)
+        )
+
+        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.events.test {
+            viewModel.signIn("username", "password")
+            awaitItem().shouldBeError(causeMessage = "Authenticator does not yet support TOTP workflows.")
+        }
+    }
+
+//endregion
+//region helpers
+    private val AuthenticatorViewModel.currentStep: AuthenticatorStep
+        get() = stepState.value.step
+//endregion
+}

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.ui.authenticator
+
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.AuthSession
+import com.amplifyframework.auth.AuthUser
+import com.amplifyframework.auth.MFAType
+import com.amplifyframework.auth.TOTPSetupDetails
+import com.amplifyframework.auth.result.AuthSignInResult
+import com.amplifyframework.auth.result.step.AuthNextSignInStep
+import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.ui.authenticator.enums.AuthenticatorInitialStep
+import com.amplifyframework.ui.authenticator.enums.AuthenticatorStep
+import com.amplifyframework.ui.authenticator.forms.SignUpFormBuilder
+
+internal fun mockAuthConfiguration(
+    initialStep: AuthenticatorInitialStep = AuthenticatorStep.SignIn,
+    signUpForm: SignUpFormBuilder.() -> Unit = {}
+) = AuthenticatorConfiguration(
+    initialStep = initialStep,
+    signUpForm = signUpForm
+)
+
+internal fun mockAuthException(
+    message: String = "A test exception",
+    recoverySuggestion: String = "A test suggestion",
+    cause: Throwable? = null
+) = AuthException(
+    message = message,
+    recoverySuggestion = recoverySuggestion,
+    cause = cause
+)
+
+internal fun mockAuthSession(
+    isSignedIn: Boolean = false
+) = AuthSession(isSignedIn)
+
+internal fun mockAuthUser(
+    userId: String = "userId",
+    username: String = "username"
+) = AuthUser(userId, username)
+
+internal fun mockSignInResult(
+    isSignedIn: Boolean = true,
+    nextSignInStep: AuthNextSignInStep = mockNextSignInStep()
+) = AuthSignInResult(isSignedIn, nextSignInStep)
+
+internal fun mockSignInResult(
+    signInStep: AuthSignInStep = AuthSignInStep.DONE,
+    additionalInfo: Map<String, String> = emptyMap(),
+    codeDeliveryDetails: AuthCodeDeliveryDetails? = null,
+    totpSetupDetails: TOTPSetupDetails? = null,
+    allowedMFATypes: Set<MFAType>? = null
+) = AuthSignInResult(
+    signInStep == AuthSignInStep.DONE,
+    mockNextSignInStep(
+        signInStep = signInStep,
+        additionalInfo = additionalInfo,
+        codeDeliveryDetails = codeDeliveryDetails,
+        totpSetupDetails = totpSetupDetails,
+        allowedMFATypes = allowedMFATypes
+    )
+)
+
+internal fun mockNextSignInStep(
+    signInStep: AuthSignInStep = AuthSignInStep.DONE,
+    additionalInfo: Map<String, String> = emptyMap(),
+    codeDeliveryDetails: AuthCodeDeliveryDetails? = null,
+    totpSetupDetails: TOTPSetupDetails? = null,
+    allowedMFATypes: Set<MFAType>? = null
+) = AuthNextSignInStep(signInStep, additionalInfo, codeDeliveryDetails, totpSetupDetails, allowedMFATypes)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,18 @@
 [versions]
 agp = "8.0.0"
-amplify = "2.11.1"
+amplify = "2.13.0"
 cameraX = "1.2.0"
 compose = "1.3.2"
+coroutines = "1.7.3"
 dokka = "1.8.10"
 lifecycle = "2.4.0"
 kotlin = "1.8.10"
 ktlint = "11.0.0"
 kover = "0.7.2"
+kotest = "5.7.1"
 material3 = "1.1.0"
 paparazzi = "1.2.0"
+turbine = "1.0.0"
 
 [libraries]
 # Amplify Dependencies
@@ -41,10 +44,13 @@ tensorflow-support = "org.tensorflow:tensorflow-lite-support:0.3.0"
 test-androidx-junit = "androidx.test.ext:junit:1.1.4"
 test-compose-junit = {  module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
+test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 test-espresso = "androidx.test.espresso:espresso-core:3.5.1"
 test-junit = "junit:junit:4.13.2"
+test-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 test-mockk = "io.mockk:mockk:1.13.4"
 test-robolectric = "org.robolectric:robolectric:4.9.2"
+test-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 # Dependencies for convention plugins
 plugin-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -56,7 +62,18 @@ plugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref =
 [bundles]
 camera = ["androidx-camera-core", "androidx-camera-camera2", "androidx-camera-lifecycle"]
 compose = ["androidx-compose-material", "androidx-compose-tooling"]
-test = ["test-androidx-junit", "test-junit", "test-mockk", "test-robolectric", "test-compose-junit", "test-compose-manifest", "test-espresso"]
+test = [
+    "test-androidx-junit",
+    "test-junit",
+    "test-mockk",
+    "test-robolectric",
+    "test-compose-junit",
+    "test-compose-manifest",
+    "test-espresso",
+    "test-coroutines",
+    "test-kotest-assertions",
+    "test-turbine"
+]
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/testing/src/main/java/com/amplifyframework/ui/testing/CoroutineTestRule.kt
+++ b/testing/src/main/java/com/amplifyframework/ui/testing/CoroutineTestRule.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.ui.testing
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * A JUnit rule that overrides the main coroutine dispatcher in tests.
+ *
+ * See https://github.com/Kotlin/kotlinx.coroutines/tree/master/kotlinx-coroutines-test for information on how to use
+ * a TestDispatcher to test code that launches coroutines.
+ *
+ * Usage:
+ * @get:Rule
+ * val coroutineRule = CoroutineTestRule()
+ * @Test
+ * fun myTest() = runTest {
+ *    // ... test code here
+ * }
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutineTestRule(private val dispatcher: TestDispatcher = StandardTestDispatcher()) : TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
Authenticator will shown a generic error message and emit a useful error log if an unsupported next step is received.

Log Message:
<img width="1545" alt="Screenshot 2023-09-12 at 2 56 17 PM" src="https://github.com/aws-amplify/amplify-ui-android/assets/2781254/dba0e3da-eea9-4eeb-9881-e68a931f9752">

UX:
![Screenshot_20230912_145651](https://github.com/aws-amplify/amplify-ui-android/assets/2781254/4a3b83f9-aa07-459a-b555-4d70c97559fe)

*How did you test these changes?*
- Tried to sign in with TOTP enabled

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
