### PR TITLE
chore: Add build-time dependency license check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,59 @@ buildscript {
         google()
         mavenCentral()
     }
+    dependencies {
+        classpath("app.cash.licensee:licensee-gradle-plugin:1.7.0")
+    }
+}
+
+subprojects {
+    apply(plugin = "app.cash.licensee")
+    configure<app.cash.licensee.LicenseeExtension> {
+        allow("Apache-2.0")
+        allow("MIT")
+        allow("BSD-2-Clause")
+        allowDependency("org.bouncycastle", "bcprov-jdk15on", "1.70") {
+            "MIT License"
+        }
+        allowDependency("org.ow2.asm", "asm", "9.4") {
+            "3-Clause BSD License"
+        }
+        allowDependency("org.ow2.asm", "asm-analysis", "9.4")
+        allowDependency("org.ow2.asm", "asm-commons", "9.4")
+        allowDependency("org.ow2.asm", "asm-tree", "9.4")
+        allowDependency("org.ow2.asm", "asm-util", "9.4")
+        allowDependency("com.ibm.icu", "icu4j", "70.1")
+        allowUrl("http://aws.amazon.com/apache2.0")
+        allowUrl("https://developer.android.com/studio/terms.html")
+
+        ignoreDependencies("javax.annotation", "javax.annotation-api") {
+            "Transitive dependency for androidx.test.espresso:espresso-core"
+        }
+        ignoreDependencies("org.junit", "junit-bom") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("org.junit", "jupiter") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("org.junit.jupiter", "junit-jupiter") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("org.junit.jupiter", "junit-jupiter-params") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("org.junit", "junit-jupiter-params") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("org.junit.platform", "junit-platform-commons") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("org.junit.platform", "junit-platform-engine") {
+            because("Unit Testing Dependency")
+        }
+        ignoreDependencies("junit", "junit") {
+            because("Unit Testing Dependency")
+        }
+    }
 }
 
 // Plugin aliases are a warning in Gradle < 8.1, this suppress can be removed after updating


### PR DESCRIPTION
- [X] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
 Add License validation step as part of `gradlew build` 

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [X] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
