### PR TITLE
fix(authenticator): Improve error messaging if auth configuration is invalid/incomplete

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -60,11 +60,13 @@ import com.amplifyframework.ui.authenticator.forms.setFieldError
 import com.amplifyframework.ui.authenticator.states.BaseStateImpl
 import com.amplifyframework.ui.authenticator.states.StepStateFactory
 import com.amplifyframework.ui.authenticator.util.AmplifyResult
+import com.amplifyframework.ui.authenticator.util.AuthConfigurationResult
 import com.amplifyframework.ui.authenticator.util.AuthProvider
 import com.amplifyframework.ui.authenticator.util.AuthenticatorMessage
 import com.amplifyframework.ui.authenticator.util.CannotSendCodeMessage
 import com.amplifyframework.ui.authenticator.util.CodeSentMessage
 import com.amplifyframework.ui.authenticator.util.ExpiredCodeMessage
+import com.amplifyframework.ui.authenticator.util.InvalidConfigurationException
 import com.amplifyframework.ui.authenticator.util.InvalidLoginMessage
 import com.amplifyframework.ui.authenticator.util.MissingConfigurationException
 import com.amplifyframework.ui.authenticator.util.NetworkErrorMessage
@@ -121,14 +123,19 @@ internal class AuthenticatorViewModel(
         this.configuration = configuration
 
         viewModelScope.launch {
-            val authConfig = authProvider.getConfiguration()
-
-            if (authConfig == null) {
-                handleGeneralFailure(MissingConfigurationException())
-                return@launch
+            when (val authConfigResult = authProvider.getConfiguration()) {
+                is AuthConfigurationResult.Invalid -> {
+                    handleGeneralFailure(
+                        InvalidConfigurationException(authConfigResult.message, authConfigResult.cause)
+                    )
+                    return@launch
+                }
+                AuthConfigurationResult.Missing -> {
+                    handleGeneralFailure(MissingConfigurationException())
+                    return@launch
+                }
+                is AuthConfigurationResult.Valid -> authConfiguration = authConfigResult.configuration
             }
-
-            authConfiguration = authConfig
 
             stateFactory = StepStateFactory(
                 authConfiguration,

--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/util/Exceptions.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/util/Exceptions.kt
@@ -26,3 +26,13 @@ class MissingConfigurationException : AuthException(
     "Make sure the Auth plugin is added and Amplify.configure is called. See " +
         "https://docs.amplify.aws/lib/auth/getting-started/q/platform/android/ for details"
 )
+
+/**
+ * Exception that is passed to the errorContent if the configuration passed to the auth plugin is missing a required
+ * property or has an invalid property
+ */
+class InvalidConfigurationException(message: String, cause: Exception?) : AuthException(
+    message = message,
+    recoverySuggestion = "Check that the configuration passed to Amplify.configure has all required fields",
+    cause = cause
+)


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
#105 
#98 

*Description of changes:*
Log a more descriptive error if amplify configuration is incomplete or invalid.

Log messages now look like:
> InvalidConfigurationException{message=No value for verificationMechanisms, cause=org.json.JSONException: No value for verificationMechanisms, recoverySuggestion=Check that the configuration passed to Amplify.configure has all required fields}

*How did you test these changes?*
- Removed/edited fields in my amplifyconfiguration.json, ran Authenticator

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
