### PR TITLE
chore: Ignore VisibleForTesting-annotated elements for purposes of api validation

### DIFF
--- a/build-logic/plugins/src/main/kotlin/ApiValidatorConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/ApiValidatorConventionPlugin.kt
@@ -30,6 +30,7 @@ class ApiValidatorConventionPlugin : Plugin<Project> {
             extensions.configure<ApiValidationExtension> {
                 // Ignore anything marked with an internal API marker
                 nonPublicMarkers += amplifyInternalMarkers
+                nonPublicMarkers += "androidx.annotation.VisibleForTesting"
             }
         }
     }


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
- Elements marked `@VisibleForTesting` are not part of the public API

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
