### PR TITLE
fix(authenticator): Do not show empty user verification screen

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -408,7 +408,7 @@ internal class AuthenticatorViewModel(
                     }
                     val verificationAttributeKeys = mechanisms.map { it.toAttributeKey() }
                     val verificationAttributes = result.data.filter { verificationAttributeKeys.contains(it.key) }
-                    if (hasVerified) {
+                    if (hasVerified || verificationAttributes.isEmpty()) {
                         handleSignedIn()
                     } else {
                         val newState = stateFactory.newVerifyUserState(

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -16,10 +16,14 @@
 package com.amplifyframework.ui.authenticator
 
 import android.app.Application
+import com.amplifyframework.auth.AuthUserAttributeKey.email
+import com.amplifyframework.auth.AuthUserAttributeKey.emailVerified
 import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.ui.authenticator.auth.VerificationMechanism
 import com.amplifyframework.ui.authenticator.enums.AuthenticatorStep
 import com.amplifyframework.ui.authenticator.util.AmplifyResult
+import com.amplifyframework.ui.authenticator.util.AmplifyResult.Success
 import com.amplifyframework.ui.authenticator.util.AuthConfigurationResult
 import com.amplifyframework.ui.authenticator.util.AuthProvider
 import com.amplifyframework.ui.testing.CoroutineTestRule
@@ -50,15 +54,16 @@ class AuthenticatorViewModelTest {
 
     @Before
     fun setup() {
-        coEvery { authProvider.getConfiguration() } returns AuthConfigurationResult.Valid(mockk(relaxed = true))
+        coEvery { authProvider.getConfiguration() } returns mockAmplifyAuthConfiguration()
+        coEvery { authProvider.getCurrentUser() } returns Success(mockUser())
     }
 
 //region start tests
 
     @Test
     fun `start only executes once`() = runTest {
-        viewModel.start(mockAuthConfiguration())
-        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
         advanceUntilIdle()
 
         // fetchAuthSession only called by the first start
@@ -71,7 +76,7 @@ class AuthenticatorViewModelTest {
     fun `missing configuration results in an error`() = runTest {
         coEvery { authProvider.getConfiguration() } returns AuthConfigurationResult.Missing
 
-        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
         advanceUntilIdle()
 
         coVerify(exactly = 0) { authProvider.fetchAuthSession() }
@@ -82,7 +87,7 @@ class AuthenticatorViewModelTest {
     fun `invalid configuration results in an error`() = runTest {
         coEvery { authProvider.getConfiguration() } returns AuthConfigurationResult.Invalid("Invalid")
 
-        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
         advanceUntilIdle()
 
         coVerify(exactly = 0) { authProvider.fetchAuthSession() }
@@ -93,7 +98,7 @@ class AuthenticatorViewModelTest {
     fun `fetchAuthSession error during start results in an error`() = runTest {
         coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Error(mockAuthException())
 
-        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
         advanceUntilIdle()
 
         coVerify(exactly = 1) { authProvider.fetchAuthSession() }
@@ -102,10 +107,10 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `getCurrentUser error during start results in an error`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = true))
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = true))
         coEvery { authProvider.getCurrentUser() } returns AmplifyResult.Error(mockAuthException())
 
-        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
@@ -117,10 +122,10 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `when already signed in during start the initial state should be signed in`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = true))
-        coEvery { authProvider.getCurrentUser() } returns AmplifyResult.Success(mockAuthUser())
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = true))
+        coEvery { authProvider.getCurrentUser() } returns Success(mockAuthUser())
 
-        viewModel.start(mockAuthConfiguration())
+        viewModel.start(mockAuthenticatorConfiguration())
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
@@ -132,9 +137,9 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `initial step is SignIn`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
         advanceUntilIdle()
 
         viewModel.currentStep shouldBe AuthenticatorStep.SignIn
@@ -145,15 +150,15 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `TOTPSetup next step shows error if totpSetupDetails is null`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
-        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
             mockSignInResult(
                 signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_TOTP_SETUP,
                 totpSetupDetails = null
             )
         )
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
 
         viewModel.signIn("username", "password")
         viewModel.currentStep shouldBe AuthenticatorStep.Error
@@ -161,15 +166,15 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `TOTPSetup next step shows SignInContinueWithTotpSetup screen`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
-        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
             mockSignInResult(
                 signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_TOTP_SETUP,
                 totpSetupDetails = mockk(relaxed = true)
             )
         )
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
 
         viewModel.signIn("username", "password")
         viewModel.currentStep shouldBe AuthenticatorStep.SignInContinueWithTotpSetup
@@ -177,12 +182,12 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `TOTP Code next step shows the SignInConfirmTotpCode screen`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
-        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
             mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_IN_WITH_TOTP_CODE)
         )
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
 
         viewModel.signIn("username", "password")
         viewModel.currentStep shouldBe AuthenticatorStep.SignInConfirmTotpCode
@@ -190,15 +195,15 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `MFA selection next step shows error if allowedMFATypes is null`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
-        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
             mockSignInResult(
                 signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_MFA_SELECTION,
                 allowedMFATypes = null
             )
         )
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
 
         viewModel.signIn("username", "password")
         viewModel.currentStep shouldBe AuthenticatorStep.Error
@@ -206,15 +211,15 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `MFA selection next step shows error if allowedMFATypes is empty`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
-        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
             mockSignInResult(
                 signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_MFA_SELECTION,
                 allowedMFATypes = emptySet()
             )
         )
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
 
         viewModel.signIn("username", "password")
         viewModel.currentStep shouldBe AuthenticatorStep.Error
@@ -222,18 +227,100 @@ class AuthenticatorViewModelTest {
 
     @Test
     fun `MFA Selection next step shows the SignInContinueWithMfaSelection screen`() = runTest {
-        coEvery { authProvider.fetchAuthSession() } returns AmplifyResult.Success(mockAuthSession(isSignedIn = false))
-        coEvery { authProvider.signIn(any(), any()) } returns AmplifyResult.Success(
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
             mockSignInResult(
                 signInStep = AuthSignInStep.CONTINUE_SIGN_IN_WITH_MFA_SELECTION,
                 allowedMFATypes = setOf(MFAType.TOTP, MFAType.SMS)
             )
         )
 
-        viewModel.start(mockAuthConfiguration(initialStep = AuthenticatorStep.SignIn))
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
 
         viewModel.signIn("username", "password")
         viewModel.currentStep shouldBe AuthenticatorStep.SignInContinueWithMfaSelection
+    }
+
+    @Test
+    fun `user attribute verification screen is shown if user has no verified attributes`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
+        coEvery { authProvider.getConfiguration() } returns mockAmplifyAuthConfiguration(
+            verificationMechanisms = setOf(VerificationMechanism.Email)
+        )
+        coEvery { authProvider.fetchUserAttributes() } returns Success(
+            mockUserAttributes(email() to "email", emailVerified() to "false")
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.signIn("username", "password")
+
+        viewModel.currentStep shouldBe AuthenticatorStep.VerifyUser
+    }
+
+    @Test
+    fun `user attribute verification screen is not shown if user has verified attributes`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
+        coEvery { authProvider.getConfiguration() } returns mockAmplifyAuthConfiguration(
+            verificationMechanisms = setOf(VerificationMechanism.Email)
+        )
+        coEvery { authProvider.fetchUserAttributes() } returns Success(
+            mockUserAttributes(email() to "email", emailVerified() to "true") // email is already verified
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.signIn("username", "password")
+
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
+    }
+
+    @Test
+    fun `user attribute verification screen is not shown if there are no verification mechanisms`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
+        coEvery { authProvider.getConfiguration() } returns mockAmplifyAuthConfiguration(
+            verificationMechanisms = emptySet() // no verification mechanisms
+        )
+        coEvery { authProvider.fetchUserAttributes() } returns Success(
+            mockUserAttributes(email() to "email", emailVerified() to "false")
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.signIn("username", "password")
+
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
+    }
+
+    @Test
+    fun `user attribute verification screen is not shown if cannot fetch user attributes`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
+        coEvery { authProvider.getConfiguration() } returns mockAmplifyAuthConfiguration(
+            verificationMechanisms = setOf(VerificationMechanism.Email)
+        )
+        // cannot fetch user attributes
+        coEvery { authProvider.fetchUserAttributes() } returns AmplifyResult.Error(mockk(relaxed = true))
+
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.signIn("username", "password")
+
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
+    }
+
+    @Test
+    fun `user attribute verification screen is not shown if user does not have the required attributes`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
+        coEvery { authProvider.getConfiguration() } returns mockAmplifyAuthConfiguration(
+            verificationMechanisms = setOf(VerificationMechanism.Email)
+        )
+        coEvery { authProvider.fetchUserAttributes() } returns Success(mockUserAttributes()) // no email attribute
+
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.signIn("username", "password")
+
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
     }
 
 //endregion

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
@@ -19,17 +19,25 @@ import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.AuthUser
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.step.AuthNextSignInStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.ui.authenticator.auth.AmplifyAuthConfiguration
+import com.amplifyframework.ui.authenticator.auth.PasswordCriteria
+import com.amplifyframework.ui.authenticator.auth.SignInMethod
+import com.amplifyframework.ui.authenticator.auth.VerificationMechanism
 import com.amplifyframework.ui.authenticator.enums.AuthenticatorInitialStep
 import com.amplifyframework.ui.authenticator.enums.AuthenticatorStep
 import com.amplifyframework.ui.authenticator.forms.SignUpFormBuilder
 import com.amplifyframework.ui.authenticator.options.TotpOptions
+import com.amplifyframework.ui.authenticator.util.AuthConfigurationResult
+import io.mockk.mockk
 
-internal fun mockAuthConfiguration(
+internal fun mockAuthenticatorConfiguration(
     initialStep: AuthenticatorInitialStep = AuthenticatorStep.SignIn,
     signUpForm: SignUpFormBuilder.() -> Unit = {},
     totpOptions: TotpOptions? = null
@@ -37,6 +45,20 @@ internal fun mockAuthConfiguration(
     initialStep = initialStep,
     signUpForm = signUpForm,
     totpOptions = totpOptions
+)
+
+internal fun mockAmplifyAuthConfiguration(
+    signInMethod: SignInMethod = SignInMethod.Username,
+    signUpAttributes: List<AuthUserAttributeKey> = emptyList(),
+    passwordCriteria: PasswordCriteria = mockk(relaxed = true),
+    verificationMechanisms: Set<VerificationMechanism> = emptySet()
+) = AuthConfigurationResult.Valid(
+    AmplifyAuthConfiguration(
+        signInMethod = signInMethod,
+        signUpAttributes = signUpAttributes,
+        passwordCriteria = passwordCriteria,
+        verificationMechanisms = verificationMechanisms
+    )
 )
 
 internal fun mockAuthException(
@@ -87,3 +109,12 @@ internal fun mockNextSignInStep(
     totpSetupDetails: TOTPSetupDetails? = null,
     allowedMFATypes: Set<MFAType>? = null
 ) = AuthNextSignInStep(signInStep, additionalInfo, codeDeliveryDetails, totpSetupDetails, allowedMFATypes)
+
+internal fun mockUserAttributes(
+    vararg attribute: Pair<AuthUserAttributeKey, String>
+) = attribute.map { AuthUserAttribute(it.first, it.second) }
+
+internal fun mockUser(
+    userId: String = "userId",
+    username: String = "username"
+) = AuthUser(userId, username)


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
#128 

*Description of changes:*
If user does not have any of the required verification attributes do not show the attribute verification screen (because there is nothing to verify)

Added various unit tests around showing the attribute verification screen.

*How did you test these changes?*
Followed steps described in issue

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
