### PR TITLE
fix(authenticator): Fix emission of NetworkErrorMessage

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -76,8 +76,8 @@ import com.amplifyframework.ui.authenticator.util.PasswordResetMessage
 import com.amplifyframework.ui.authenticator.util.RealAuthProvider
 import com.amplifyframework.ui.authenticator.util.UnableToResetPasswordMessage
 import com.amplifyframework.ui.authenticator.util.UnknownErrorMessage
+import com.amplifyframework.ui.authenticator.util.isConnectivityIssue
 import com.amplifyframework.ui.authenticator.util.toFieldError
-import java.net.UnknownHostException
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -554,7 +554,7 @@ internal class AuthenticatorViewModel(
             is CodeExpiredException -> sendMessage(ExpiredCodeMessage(error))
             is CodeValidationException -> sendMessage(UnknownErrorMessage(error))
             is UnknownException -> {
-                if (error.cause is UnknownHostException) {
+                if (error.isConnectivityIssue()) {
                     sendMessage(NetworkErrorMessage(error))
                 } else {
                     sendMessage(UnknownErrorMessage(error))

--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/util/Exceptions.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/util/Exceptions.kt
@@ -16,6 +16,7 @@
 package com.amplifyframework.ui.authenticator.util
 
 import com.amplifyframework.auth.AuthException
+import java.net.UnknownHostException
 
 /**
  * Exception that is passed to the errorContent if the application does not have the auth plugin
@@ -36,3 +37,13 @@ class InvalidConfigurationException(message: String, cause: Exception?) : AuthEx
     recoverySuggestion = "Check that the configuration passed to Amplify.configure has all required fields",
     cause = cause
 )
+
+internal fun Throwable.isConnectivityIssue(): Boolean {
+    if (this is UnknownHostException) {
+        return true
+    }
+    return when (val cause = this.cause) {
+        null -> false
+        else -> cause.isConnectivityIssue()
+    }
+}

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorMatchers.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorMatchers.kt
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.ui.authenticator
 
+import app.cash.turbine.test
 import com.amplifyframework.ui.authenticator.util.AuthenticatorMessage
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
@@ -44,4 +45,13 @@ fun AuthenticatorMessage?.shouldBeError(
     val casted = this.shouldBeInstanceOf<AuthenticatorMessage.Error>()
     causeMessage?.let { casted should haveMessage(it) }
     recoverySuggestion?.let { casted should haveRecoverySuggestion(it) }
+}
+
+internal suspend inline fun <reified T : AuthenticatorMessage> AuthenticatorViewModel.shouldEmitMessage(
+    crossinline block: suspend () -> Unit
+) {
+    events.test {
+        block()
+        awaitItem().shouldBeInstanceOf<T>()
+    }
 }


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:* #151

*Description of changes:*
Instead of only checking direct `cause`, look through the chain of `cause` to see if an error's root cause was a network error.

*How did you test these changes?*
- Verified expected connectivity message appears when trying to sign in with airplane mode.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
