### PR TITLE
chore: Remove characters from comment bodies before calling xargs

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -16,7 +16,7 @@ jobs:
           BODY: ${{ toJson(github.event.comment.body) }}
           COMMENT_URL: ${{github.event.comment.html_url}}
         shell: bash
-        run: echo $BODY | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'"}'
+        run: echo $BODY | sed "s/\\\n/. /g; s/\\\r//g; s/[^a-zA-Z0-9 &().,:]//g" | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'"}'
 
   remove-pending-response-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
- Some comments don't trigger the webhook because they have characters that are invalid for xargs.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
