### PR TITLE
feat(liveness): Add support for a no light freshness challenge 

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/LivenessCoordinator.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/LivenessCoordinator.kt
@@ -77,9 +77,6 @@ internal class LivenessCoordinator(
 
     private val analysisExecutor = Executors.newSingleThreadExecutor()
 
-    private var attemptCount: Int = 0
-    private var latestAttemptTimeStamp: Long = System.currentTimeMillis()
-
     val livenessState = LivenessState(
         sessionId = sessionId,
         context = context,
@@ -266,8 +263,8 @@ internal class LivenessCoordinator(
         )
     }
 
-    fun processFreshnessChallengeComplete() {
-        livenessState.onFreshnessComplete()
+    fun processLivenessCheckComplete() {
+        livenessState.onLivenessChallengeComplete()
         stopEncoder { livenessState.onFullChallengeComplete() }
     }
 
@@ -317,5 +314,7 @@ internal class LivenessCoordinator(
         const val TARGET_ENCODE_KEYFRAME_INTERVAL = 1 // webm muxer only flushes to file on keyframe
         val TARGET_RESOLUTION_SIZE = Size(TARGET_WIDTH, TARGET_HEIGHT)
         const val ATTEMPT_COUNT_RESET_INTERVAL_MS = 300_000L
+        var attemptCount = 0
+        var latestAttemptTimeStamp: Long = System.currentTimeMillis()
     }
 }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/model/FaceLivenessDetectionException.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/model/FaceLivenessDetectionException.kt
@@ -45,6 +45,13 @@ open class FaceLivenessDetectionException(
         throwable: Throwable? = null
     ) : FaceLivenessDetectionException(message, recoverySuggestion, throwable)
 
+    class UnsupportedChallengeTypeException(
+        message: String = "Received an unsupported ChallengeType from the backend.",
+        recoverySuggestion: String = "Verify that the Challenges configured in your backend are supported by " +
+                "this library.",
+        throwable: Throwable? = null
+    ) : FaceLivenessDetectionException(message, recoverySuggestion, throwable)
+
     class UserCancelledException(
         message: String = "User cancelled the face liveness check.",
         recoverySuggestion: String = "Retry the face liveness check.",

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/model/FaceLivenessDetectionException.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/model/FaceLivenessDetectionException.kt
@@ -48,7 +48,7 @@ open class FaceLivenessDetectionException(
     class UnsupportedChallengeTypeException(
         message: String = "Received an unsupported ChallengeType from the backend.",
         recoverySuggestion: String = "Verify that the Challenges configured in your backend are supported by " +
-                "this library.",
+            "this library.",
         throwable: Throwable? = null
     ) : FaceLivenessDetectionException(message, recoverySuggestion, throwable)
 

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/model/LivenessCheckState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/model/LivenessCheckState.kt
@@ -19,10 +19,10 @@ import android.graphics.RectF
 import com.amplifyframework.ui.liveness.R
 import com.amplifyframework.ui.liveness.ml.FaceDetector
 
-internal sealed class LivenessCheckState(open val instructionId: Int? = null, open val isActionable: Boolean = true) {
-    data class Initial(
-        override val instructionId: Int? = null,
-        override val isActionable: Boolean = true
+internal sealed class LivenessCheckState(val instructionId: Int? = null, val isActionable: Boolean = true) {
+    class Initial(
+        instructionId: Int? = null,
+        isActionable: Boolean = true
     ) : LivenessCheckState(instructionId, isActionable) {
         companion object {
             fun withMoveFaceMessage() =
@@ -37,7 +37,7 @@ internal sealed class LivenessCheckState(open val instructionId: Int? = null, op
                 Initial(R.string.amplify_ui_liveness_get_ready_center_face_label)
         }
     }
-    data class Running(override val instructionId: Int? = null) : LivenessCheckState(instructionId, true) {
+    class Running(instructionId: Int? = null) : LivenessCheckState(instructionId, true) {
         companion object {
             fun withMoveFaceMessage() = Running(
                 R.string.amplify_ui_liveness_challenge_instruction_move_face_closer

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/model/LivenessCheckState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/model/LivenessCheckState.kt
@@ -19,10 +19,10 @@ import android.graphics.RectF
 import com.amplifyframework.ui.liveness.R
 import com.amplifyframework.ui.liveness.ml.FaceDetector
 
-internal sealed class LivenessCheckState(val instructionId: Int? = null, val isActionable: Boolean = true) {
-    class Initial(
-        instructionId: Int? = null,
-        isActionable: Boolean = true
+internal sealed class LivenessCheckState(open val instructionId: Int? = null, open val isActionable: Boolean = true) {
+    data class Initial(
+        override val instructionId: Int? = null,
+        override val isActionable: Boolean = true
     ) : LivenessCheckState(instructionId, isActionable) {
         companion object {
             fun withMoveFaceMessage() =
@@ -37,7 +37,7 @@ internal sealed class LivenessCheckState(val instructionId: Int? = null, val isA
                 Initial(R.string.amplify_ui_liveness_get_ready_center_face_label)
         }
     }
-    class Running(instructionId: Int? = null) : LivenessCheckState(instructionId, true) {
+    data class Running(override val instructionId: Int? = null) : LivenessCheckState(instructionId, true) {
         companion object {
             fun withMoveFaceMessage() = Running(
                 R.string.amplify_ui_liveness_challenge_instruction_move_face_closer

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/state/AttemptCounter.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/state/AttemptCounter.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.ui.liveness.state
+
+class AttemptCounter {
+
+    fun getCount() = attemptCount
+
+    fun countAttempt() {
+        val timestamp = System.currentTimeMillis()
+        if (timestamp - latestAttemptTimeStamp > ATTEMPT_COUNT_RESET_INTERVAL_MS) {
+            // Reset interval has lapsed so reset the attemptCount
+            attemptCount = 0
+        }
+
+        attemptCount += 1
+        latestAttemptTimeStamp = timestamp
+    }
+
+    companion object {
+        const val ATTEMPT_COUNT_RESET_INTERVAL_MS = 300_000L
+        var attemptCount = 0
+        var latestAttemptTimeStamp: Long = System.currentTimeMillis()
+    }
+}

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
@@ -50,7 +50,7 @@ internal data class LivenessState(
     val onFinalEventsSent: () -> Unit,
 ) {
     var videoViewportSize: VideoViewportSize? by mutableStateOf(null)
-    var livenessCheckState = mutableStateOf<LivenessCheckState>(
+    var livenessCheckState by mutableStateOf<LivenessCheckState>(
         LivenessCheckState.Initial()
     )
     var faceMatched by mutableStateOf(false)
@@ -87,14 +87,14 @@ internal data class LivenessState(
     }
 
     fun onError(stopLivenessSession: Boolean, webSocketCloseCode: WebSocketCloseCode) {
-        livenessCheckState.value = LivenessCheckState.Error
+        livenessCheckState = LivenessCheckState.Error
         onDestroy(stopLivenessSession, webSocketCloseCode)
     }
 
     // Cleans up state when challenge is completed or cancelled.
     // We only send webSocketCloseCode if error encountered.
     fun onDestroy(stopLivenessSession: Boolean, webSocketCloseCode: WebSocketCloseCode? = null) {
-        livenessCheckState.value = LivenessCheckState.Error
+        livenessCheckState = LivenessCheckState.Error
         faceOvalMatchTimer?.cancel()
         readyForOval = false
         faceGuideRect = null
@@ -126,7 +126,7 @@ internal data class LivenessState(
             faceMatchOvalEnd = Date().time
         }
 
-        livenessCheckState.value = if (faceGuideRect != null) {
+        livenessCheckState = if (faceGuideRect != null) {
             LivenessCheckState.Success(faceGuideRect)
         } else {
             LivenessCheckState.Error
@@ -139,7 +139,7 @@ internal data class LivenessState(
     fun onFrameAvailable(): Boolean {
         if (showingStartView) return false
 
-        return when (val livenessCheckState = livenessCheckState.value) {
+        return when (val livenessCheckState = livenessCheckState) {
             is LivenessCheckState.Error -> false
             is LivenessCheckState.Initial, is LivenessCheckState.Running -> {
                 /**
@@ -183,10 +183,10 @@ internal data class LivenessState(
         }
         when (faceCount) {
             0 -> {
-                if (!initialLocalFaceFound || livenessCheckState.value is LivenessCheckState.Initial) {
-                    livenessCheckState.value = LivenessCheckState.Initial.withMoveFaceMessage()
-                } else if (livenessCheckState.value is LivenessCheckState.Running) {
-                    livenessCheckState.value = LivenessCheckState.Running.withMoveFaceMessage()
+                if (!initialLocalFaceFound || livenessCheckState is LivenessCheckState.Initial) {
+                    livenessCheckState = LivenessCheckState.Initial.withMoveFaceMessage()
+                } else if (livenessCheckState is LivenessCheckState.Running) {
+                    livenessCheckState = LivenessCheckState.Running.withMoveFaceMessage()
                 }
             }
             1 -> {
@@ -195,10 +195,10 @@ internal data class LivenessState(
                 }
             }
             else -> {
-                if (!initialLocalFaceFound || livenessCheckState.value is LivenessCheckState.Initial) {
-                    livenessCheckState.value = LivenessCheckState.Initial.withMultipleFaceMessage()
-                } else if (livenessCheckState.value is LivenessCheckState.Running) {
-                    livenessCheckState.value = LivenessCheckState.Running.withMultipleFaceMessage()
+                if (!initialLocalFaceFound || livenessCheckState is LivenessCheckState.Initial) {
+                    livenessCheckState = LivenessCheckState.Initial.withMultipleFaceMessage()
+                } else if (livenessCheckState is LivenessCheckState.Running) {
+                    livenessCheckState = LivenessCheckState.Running.withMultipleFaceMessage()
                 }
             }
         }
@@ -223,7 +223,7 @@ internal data class LivenessState(
                 LivenessCoordinator.TARGET_WIDTH, LivenessCoordinator.TARGET_HEIGHT
             )
             if (faceDistance >= FaceDetector.INITIAL_FACE_DISTANCE_THRESHOLD) {
-                livenessCheckState.value =
+                livenessCheckState =
                     LivenessCheckState.Initial.withMoveFaceFurtherAwayMessage()
             } else {
                 initialFaceDistanceCheckPassed = true
@@ -274,11 +274,11 @@ internal data class LivenessState(
                 faceOvalPosition == FaceDetector.FaceOvalPosition.MATCHED
 
             if (detectedFaceMatchedOval) {
-                livenessCheckState.value = LivenessCheckState.Running.withFaceOvalPosition(
+                livenessCheckState = LivenessCheckState.Running.withFaceOvalPosition(
                     FaceDetector.FaceOvalPosition.MATCHED
                 )
             } else {
-                livenessCheckState.value = LivenessCheckState.Running.withFaceOvalPosition(
+                livenessCheckState = LivenessCheckState.Running.withFaceOvalPosition(
                     faceOvalPosition
                 )
             }
@@ -310,7 +310,7 @@ internal data class LivenessState(
     }
 
     fun onStartViewComplete() {
-        livenessCheckState.value = LivenessCheckState.Running()
+        livenessCheckState = LivenessCheckState.Running()
         showingStartView = false
     }
 }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -411,7 +411,8 @@ private fun shouldDisplayInstruction(
 ): Boolean =
     if (challengeType == null) {
         true
-    } else if (livenessCheckState == LivenessCheckState.Running.withFaceOvalPosition(FaceDetector.FaceOvalPosition.MATCHED) &&
+    } else if (livenessCheckState ==
+        LivenessCheckState.Running.withFaceOvalPosition(FaceDetector.FaceOvalPosition.MATCHED) &&
         challengeType == FaceLivenessChallengeType.FaceMovementChallenge
     ) {
         false

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -249,7 +249,8 @@ internal fun ChallengeView(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     if (livenessState.livenessSessionInfo?.challengeType ==
-                        FaceLivenessChallengeType.FaceMovementAndLightChallenge) {
+                        FaceLivenessChallengeType.FaceMovementAndLightChallenge
+                    ) {
                         PhotosensitivityView {
                             showPhotosensitivityAlert.value = true
                         }
@@ -293,7 +294,8 @@ internal fun ChallengeView(
 
                 if (livenessState.faceMatched) {
                     if (livenessState.livenessSessionInfo?.challengeType ==
-                        FaceLivenessChallengeType.FaceMovementAndLightChallenge) {
+                        FaceLivenessChallengeType.FaceMovementAndLightChallenge
+                    ) {
                         FreshnessChallenge(
                             key,
                             modifier = Modifier.fillMaxSize(),
@@ -353,7 +355,11 @@ internal fun ChallengeView(
                                 verticalArrangement = Arrangement.spacedBy(5.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
-                                if (shouldDisplayInstruction(livenessState.livenessCheckState.value, livenessState.livenessSessionInfo?.challengeType!!)) {
+                                if (shouldDisplayInstruction(
+                                        livenessState.livenessCheckState.value,
+                                        livenessState.livenessSessionInfo?.challengeType!!
+                                    )
+                                ) {
                                     InstructionMessage(livenessState.livenessCheckState.value)
                                 }
                                 if (livenessState.livenessCheckState.value.instructionId ==
@@ -403,7 +409,11 @@ private fun shouldDisplayInstruction(
     livenessCheckState: LivenessCheckState,
     challengeType: FaceLivenessChallengeType
 ): Boolean {
-    return !(livenessCheckState ==
-            LivenessCheckState.Running.withFaceOvalPosition(FaceDetector.FaceOvalPosition.MATCHED) &&
-        challengeType == FaceLivenessChallengeType.FaceMovementChallenge)
+    return !(
+        livenessCheckState ==
+            LivenessCheckState.Running.withFaceOvalPosition(
+                FaceDetector.FaceOvalPosition.MATCHED
+            ) &&
+            challengeType == FaceLivenessChallengeType.FaceMovementChallenge
+        )
 }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -249,7 +249,7 @@ internal fun ChallengeView(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    if (isFaceMovementAndLightChallenge(livenessState.livenessSessionInfo)) {
+                    if (livenessState.livenessSessionInfo.isFaceMovementAndLightChallenge()) {
                         PhotosensitivityView {
                             showPhotosensitivityAlert.value = true
                         }
@@ -292,7 +292,7 @@ internal fun ChallengeView(
                 }
 
                 if (livenessState.faceMatched) {
-                    if (isFaceMovementAndLightChallenge(livenessState.livenessSessionInfo)) {
+                    if (livenessState.livenessSessionInfo.isFaceMovementAndLightChallenge()) {
                         FreshnessChallenge(
                             key,
                             modifier = Modifier.fillMaxSize(),
@@ -353,13 +353,13 @@ internal fun ChallengeView(
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 if (shouldDisplayInstruction(
-                                        livenessState.livenessCheckState.value,
+                                        livenessState.livenessCheckState,
                                         livenessState.livenessSessionInfo?.challengeType
                                     )
                                 ) {
-                                    InstructionMessage(livenessState.livenessCheckState.value)
+                                    InstructionMessage(livenessState.livenessCheckState)
                                 }
-                                if (livenessState.livenessCheckState.value.instructionId ==
+                                if (livenessState.livenessCheckState.instructionId ==
                                     FaceDetector.FaceOvalPosition.TOO_FAR.instructionStringRes
                                 ) {
                                     val scaledOvalRect = livenessState.faceGuideRect?.let {
@@ -392,7 +392,7 @@ internal fun ChallengeView(
                                 verticalArrangement = Arrangement.spacedBy(16.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
-                                InstructionMessage(livenessState.livenessCheckState.value)
+                                InstructionMessage(livenessState.livenessCheckState)
                             }
                         }
                     }
@@ -402,8 +402,8 @@ internal fun ChallengeView(
     }
 }
 
-private fun isFaceMovementAndLightChallenge(livenessSessionInfo: FaceLivenessSession?): Boolean =
-    livenessSessionInfo?.challengeType == FaceLivenessChallengeType.FaceMovementAndLightChallenge
+private fun FaceLivenessSession?.isFaceMovementAndLightChallenge(): Boolean =
+    this?.challengeType == FaceLivenessChallengeType.FaceMovementAndLightChallenge
 
 private fun shouldDisplayInstruction(
     livenessCheckState: LivenessCheckState,

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -56,6 +56,7 @@ import com.amplifyframework.auth.AWSCredentialsProvider
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.predictions.models.FaceLivenessChallengeType
+import com.amplifyframework.predictions.models.FaceLivenessSession
 import com.amplifyframework.ui.liveness.R
 import com.amplifyframework.ui.liveness.camera.LivenessCoordinator
 import com.amplifyframework.ui.liveness.camera.OnChallengeComplete
@@ -248,9 +249,7 @@ internal fun ChallengeView(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    if (livenessState.livenessSessionInfo?.challengeType ==
-                        FaceLivenessChallengeType.FaceMovementAndLightChallenge
-                    ) {
+                    if (isFaceMovementAndLightChallenge(livenessState.livenessSessionInfo)) {
                         PhotosensitivityView {
                             showPhotosensitivityAlert.value = true
                         }
@@ -293,9 +292,7 @@ internal fun ChallengeView(
                 }
 
                 if (livenessState.faceMatched) {
-                    if (livenessState.livenessSessionInfo?.challengeType ==
-                        FaceLivenessChallengeType.FaceMovementAndLightChallenge
-                    ) {
+                    if (isFaceMovementAndLightChallenge(livenessState.livenessSessionInfo)) {
                         FreshnessChallenge(
                             key,
                             modifier = Modifier.fillMaxSize(),
@@ -357,7 +354,7 @@ internal fun ChallengeView(
                             ) {
                                 if (shouldDisplayInstruction(
                                         livenessState.livenessCheckState.value,
-                                        livenessState.livenessSessionInfo?.challengeType!!
+                                        livenessState.livenessSessionInfo?.challengeType
                                     )
                                 ) {
                                     InstructionMessage(livenessState.livenessCheckState.value)
@@ -405,15 +402,19 @@ internal fun ChallengeView(
     }
 }
 
+private fun isFaceMovementAndLightChallenge(livenessSessionInfo: FaceLivenessSession?): Boolean =
+    livenessSessionInfo?.challengeType == FaceLivenessChallengeType.FaceMovementAndLightChallenge
+
 private fun shouldDisplayInstruction(
     livenessCheckState: LivenessCheckState,
-    challengeType: FaceLivenessChallengeType
-): Boolean {
-    return !(
-        livenessCheckState ==
-            LivenessCheckState.Running.withFaceOvalPosition(
-                FaceDetector.FaceOvalPosition.MATCHED
-            ) &&
-            challengeType == FaceLivenessChallengeType.FaceMovementChallenge
-        )
-}
+    challengeType: FaceLivenessChallengeType?
+): Boolean =
+    if (challengeType == null) {
+        true
+    } else if (livenessCheckState == LivenessCheckState.Running.withFaceOvalPosition(FaceDetector.FaceOvalPosition.MATCHED) &&
+        challengeType == FaceLivenessChallengeType.FaceMovementChallenge
+    ) {
+        false
+    } else {
+        true
+    }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -291,7 +291,7 @@ internal fun ChallengeView(
                     )
                 }
 
-                if (livenessState.runningFreshness) {
+                if (livenessState.faceMatched) {
                     if (livenessState.livenessSessionInfo?.challengeType ==
                         FaceLivenessChallengeType.FaceMovementAndLightChallenge) {
                         FreshnessChallenge(
@@ -307,12 +307,12 @@ internal fun ChallengeView(
                                 )
                             },
                             onComplete = {
-                                livenessCoordinator.processFreshnessChallengeComplete()
+                                livenessCoordinator.processLivenessCheckComplete()
                             }
                         )
                     } else {
                         LaunchedEffect(key) {
-                            livenessCoordinator.processFreshnessChallengeComplete()
+                            livenessCoordinator.processLivenessCheckComplete()
                         }
                     }
                 }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -55,6 +55,7 @@ import com.amplifyframework.auth.AWSCredentials
 import com.amplifyframework.auth.AWSCredentialsProvider
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
+import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import com.amplifyframework.ui.liveness.R
 import com.amplifyframework.ui.liveness.camera.LivenessCoordinator
 import com.amplifyframework.ui.liveness.camera.OnChallengeComplete
@@ -247,8 +248,11 @@ internal fun ChallengeView(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    PhotosensitivityView {
-                        showPhotosensitivityAlert.value = true
+                    if (livenessState.livenessSessionInfo?.challengeType ==
+                        FaceLivenessChallengeType.FaceMovementAndLightChallenge) {
+                        PhotosensitivityView {
+                            showPhotosensitivityAlert.value = true
+                        }
                     }
 
                     InstructionMessage(LivenessCheckState.Initial.withStartViewMessage())
@@ -277,7 +281,6 @@ internal fun ChallengeView(
                     }
                 }
             } else {
-
                 livenessState.faceGuideRect?.let {
                     FaceGuide(
                         modifier = Modifier
@@ -289,22 +292,29 @@ internal fun ChallengeView(
                 }
 
                 if (livenessState.runningFreshness) {
-                    FreshnessChallenge(
-                        key,
-                        modifier = Modifier.fillMaxSize(),
-                        colors = livenessState.colorChallenge!!.challengeColors,
-                        onColorDisplayed = { currentColor, previousColor, sequenceNumber, colorStart ->
-                            livenessCoordinator.processColorDisplayed(
-                                currentColor,
-                                previousColor,
-                                sequenceNumber,
-                                colorStart
-                            )
-                        },
-                        onComplete = {
+                    if (livenessState.livenessSessionInfo?.challengeType ==
+                        FaceLivenessChallengeType.FaceMovementAndLightChallenge) {
+                        FreshnessChallenge(
+                            key,
+                            modifier = Modifier.fillMaxSize(),
+                            colors = livenessState.colorChallenge!!.challengeColors,
+                            onColorDisplayed = { currentColor, previousColor, sequenceNumber, colorStart ->
+                                livenessCoordinator.processColorDisplayed(
+                                    currentColor,
+                                    previousColor,
+                                    sequenceNumber,
+                                    colorStart
+                                )
+                            },
+                            onComplete = {
+                                livenessCoordinator.processFreshnessChallengeComplete()
+                            }
+                        )
+                    } else {
+                        LaunchedEffect(key) {
                             livenessCoordinator.processFreshnessChallengeComplete()
                         }
-                    )
+                    }
                 }
 
                 livenessState.faceGuideRect?.let {

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -353,7 +353,9 @@ internal fun ChallengeView(
                                 verticalArrangement = Arrangement.spacedBy(5.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
-                                InstructionMessage(livenessState.livenessCheckState.value)
+                                if (shouldDisplayInstruction(livenessState.livenessCheckState.value, livenessState.livenessSessionInfo?.challengeType!!)) {
+                                    InstructionMessage(livenessState.livenessCheckState.value)
+                                }
                                 if (livenessState.livenessCheckState.value.instructionId ==
                                     FaceDetector.FaceOvalPosition.TOO_FAR.instructionStringRes
                                 ) {
@@ -395,4 +397,13 @@ internal fun ChallengeView(
             }
         }
     }
+}
+
+private fun shouldDisplayInstruction(
+    livenessCheckState: LivenessCheckState,
+    challengeType: FaceLivenessChallengeType
+): Boolean {
+    return !(livenessCheckState ==
+            LivenessCheckState.Running.withFaceOvalPosition(FaceDetector.FaceOvalPosition.MATCHED) &&
+        challengeType == FaceLivenessChallengeType.FaceMovementChallenge)
 }

--- a/liveness/src/test/java/com/amplifyframework/ui/liveness/state/LivenessStateTest.kt
+++ b/liveness/src/test/java/com/amplifyframework/ui/liveness/state/LivenessStateTest.kt
@@ -248,23 +248,23 @@ internal class LivenessStateTest {
     }
 
     @Test
-    fun `freshness stops running on freshness complete`() {
-        livenessState.onFreshnessComplete()
-        assertFalse(livenessState.runningFreshness)
+    fun `liveness challenge execution stops running on challenge completion`() {
+        livenessState.onLivenessChallengeComplete()
+        assertFalse(livenessState.faceMatched)
     }
 
     @Test
-    fun `state is success after freshness completes and no errors occur`() {
+    fun `state is success after challenge completes and no errors occur`() {
         livenessState.faceGuideRect = mockk(relaxed = true)
-        livenessState.onFreshnessComplete()
+        livenessState.onLivenessChallengeComplete()
         assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Success)
     }
 
     @Test
-    fun `state is error after freshness completes and an error occurs`() {
+    fun `state is error after challenge completes and an error occurs`() {
         livenessState.faceGuideRect = mockk(relaxed = true)
         livenessState.onError(false, WebSocketCloseCode.RUNTIME_ERROR)
-        livenessState.onFreshnessComplete()
+        livenessState.onLivenessChallengeComplete()
         assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Error)
     }
 

--- a/liveness/src/test/java/com/amplifyframework/ui/liveness/state/LivenessStateTest.kt
+++ b/liveness/src/test/java/com/amplifyframework/ui/liveness/state/LivenessStateTest.kt
@@ -124,13 +124,13 @@ internal class LivenessStateTest {
 
     @Test
     fun `beginning state is running`() {
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Running)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Running)
     }
 
     @Test
     fun `state is error after on error`() {
         livenessState.onError(true, WebSocketCloseCode.RUNTIME_ERROR)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Error)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Error)
     }
 
     @Test
@@ -237,7 +237,7 @@ internal class LivenessStateTest {
     fun `challenge runs after retrieving session info`() {
         val faceLivenessSession = mockk<FaceLivenessSession>(relaxed = true)
         livenessState.onLivenessSessionReady(faceLivenessSession)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Running)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Running)
         assertTrue(livenessState.readyForOval)
     }
 
@@ -257,7 +257,7 @@ internal class LivenessStateTest {
     fun `state is success after challenge completes and no errors occur`() {
         livenessState.faceGuideRect = mockk(relaxed = true)
         livenessState.onLivenessChallengeComplete()
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Success)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Success)
     }
 
     @Test
@@ -265,25 +265,25 @@ internal class LivenessStateTest {
         livenessState.faceGuideRect = mockk(relaxed = true)
         livenessState.onError(false, WebSocketCloseCode.RUNTIME_ERROR)
         livenessState.onLivenessChallengeComplete()
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Error)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Error)
     }
 
     @Test
     fun `stop processing frames if in error state`() {
-        livenessState.livenessCheckState.value = LivenessCheckState.Error
+        livenessState.livenessCheckState = LivenessCheckState.Error
         assertFalse(livenessState.onFrameAvailable())
     }
 
     @Test
     fun `keep processing frames if not in success or error state`() {
-        livenessState.livenessCheckState.value = LivenessCheckState.Running.withMoveFaceMessage()
+        livenessState.livenessCheckState = LivenessCheckState.Running.withMoveFaceMessage()
         assertTrue(livenessState.onFrameAvailable())
     }
 
     @Test
     fun `final events are sent when ready to send final events`() {
         val faceGuideRect = mockk<RectF>(relaxed = true)
-        livenessState.livenessCheckState.value = LivenessCheckState.Success(faceGuideRect)
+        livenessState.livenessCheckState = LivenessCheckState.Success(faceGuideRect)
         livenessState.readyToSendFinalEvents = true
         val challenges = mockk<List<FaceLivenessSessionChallenge>>(relaxed = true)
         val sendVideoEvent = mockk<(VideoEvent) -> Unit>(relaxed = true)
@@ -310,16 +310,16 @@ internal class LivenessStateTest {
     @Test
     fun `state is initial if no face found before running`() {
         livenessState.onFrameFaceCountUpdate(0)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Initial)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Initial)
     }
 
     @Test
     fun `state is running if no face found during challenges`() {
         livenessState.initialLocalFaceFound = true
-        livenessState.livenessCheckState.value =
+        livenessState.livenessCheckState =
             LivenessCheckState.Running.withMultipleFaceMessage()
         livenessState.onFrameFaceCountUpdate(0)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Running)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Running)
     }
 
     @Test
@@ -331,15 +331,15 @@ internal class LivenessStateTest {
     @Test
     fun `state is initial if multiple faces detected before running`() {
         livenessState.onFrameFaceCountUpdate(2)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Initial)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Initial)
     }
 
     @Test
     fun `state is running if multiple faces found during challenges`() {
         livenessState.initialLocalFaceFound = true
-        livenessState.livenessCheckState.value = LivenessCheckState.Running.withMoveFaceMessage()
+        livenessState.livenessCheckState = LivenessCheckState.Running.withMoveFaceMessage()
         livenessState.onFrameFaceCountUpdate(2)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Running)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Running)
     }
 
     @Test
@@ -349,7 +349,7 @@ internal class LivenessStateTest {
         val rightEye = FaceDetector.Landmark(75f, 40f)
         val mouth = FaceDetector.Landmark(40f, 80f)
         livenessState.onFrameFaceUpdate(faceRect, leftEye, rightEye, mouth)
-        assertTrue(livenessState.livenessCheckState.value is LivenessCheckState.Running)
+        assertTrue(livenessState.livenessCheckState is LivenessCheckState.Running)
     }
 
     @Test

--- a/liveness/src/test/java/com/amplifyframework/ui/liveness/state/LivenessStateTest.kt
+++ b/liveness/src/test/java/com/amplifyframework/ui/liveness/state/LivenessStateTest.kt
@@ -360,7 +360,6 @@ internal class LivenessStateTest {
         val mouth = FaceDetector.Landmark(40f, 80f)
         livenessState.onFrameFaceUpdate(faceRect, leftEye, rightEye, mouth)
         assertTrue(livenessState.initialFaceDistanceCheckPassed)
-//        verify(exactly = 1) { onFaceDistanceCheckPassed() }
     }
 
     @Test


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
N/A

*Description of changes:*
This adds support for a no-light challenge to the Liveness UI component. 

Notable Changes:
- Starts the liveness session immediately
    - This is required to start the web socket and retrieve information about what kind of liveness challenge to render
    - When starting the session, pass in a list of challenges that the component supports instead of a singular string
    - Passes in additional telemetry attributes

*How did you test these changes?*
- Updated unit tests
- Tested with the list of challenges in this PR and validated that backend will respond with one of those challenges
- Tested with a list of just FaceMovement and validated CX
- Tested with a list of just FaceMovementAndLight 2.0.0 and validated CX
- Tested with a list of just FaceMovementAndLight 1.0.0 and validated CX

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Updated Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
