### PR TITLE
fix: automatically sign in after password reset succeeds

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -424,8 +424,8 @@ internal class AuthenticatorViewModel(
 
     //endregion
     //region Password Reset
-
-    private suspend fun resetPassword(username: String) {
+    @VisibleForTesting
+    suspend fun resetPassword(username: String) {
         viewModelScope.launch {
             logger.debug("Initiating reset password")
             when (val result = authProvider.resetPassword(username)) {
@@ -435,7 +435,8 @@ internal class AuthenticatorViewModel(
         }.join()
     }
 
-    private suspend fun confirmResetPassword(username: String, password: String, code: String) {
+    @VisibleForTesting
+    suspend fun confirmResetPassword(username: String, password: String, code: String) {
         viewModelScope.launch {
             logger.debug("Confirming password reset")
             when (val result = authProvider.confirmResetPassword(username, password, code)) {

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -21,6 +21,9 @@ import com.amplifyframework.auth.AuthUserAttributeKey.email
 import com.amplifyframework.auth.AuthUserAttributeKey.emailVerified
 import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.exceptions.UnknownException
+import com.amplifyframework.auth.result.AuthResetPasswordResult
+import com.amplifyframework.auth.result.step.AuthNextResetPasswordStep
+import com.amplifyframework.auth.result.step.AuthResetPasswordStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
 import com.amplifyframework.ui.authenticator.auth.VerificationMechanism
 import com.amplifyframework.ui.authenticator.enums.AuthenticatorStep
@@ -352,6 +355,9 @@ class AuthenticatorViewModelTest {
         viewModel.currentStep shouldBe AuthenticatorStep.SignIn
     }
 
+//endregion
+//region password reset tests
+
     @Test
     fun `Sign in with temporary password requires password reset`() = runTest {
         coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
@@ -367,6 +373,110 @@ class AuthenticatorViewModelTest {
         viewModel.currentStep shouldBe AuthenticatorStep.PasswordReset
     }
 
+    @Test
+    fun `Password reset returns a result of DONE, state should be sign in`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.resetPassword(any()) } returns Success(
+            AuthResetPasswordResult(
+                true,
+                AuthNextResetPasswordStep(AuthResetPasswordStep.DONE, emptyMap(), null)
+            )
+        )
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
+
+        viewModel.resetPassword("username")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignIn
+    }
+
+    @Test
+    fun `Password reset fails with an error, state should stay in PasswordReset`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.resetPassword(any()) } returns Error(
+            mockk<UnknownException> {
+                every { cause } returns
+                        mockk<HttpException> {
+                            every { cause } returns mockk<UnknownHostException>()
+                        }
+            }
+        )
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
+
+        viewModel.resetPassword("username")
+        viewModel.currentStep shouldBe AuthenticatorStep.PasswordReset
+    }
+
+    @Test
+    fun `Password reset confirmation succeeds, sign in succeeds, state should be signed in`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.resetPassword(any()) } returns Success(
+            AuthResetPasswordResult(
+                true,
+                AuthNextResetPasswordStep(AuthResetPasswordStep.CONFIRM_RESET_PASSWORD_WITH_CODE, emptyMap(), null)
+            )
+        )
+
+        coEvery { authProvider.confirmResetPassword(any(), any(),any())} returns Success(Unit)
+        coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
+
+        viewModel.resetPassword("username")
+        viewModel.confirmResetPassword("username", "password", "code")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
+    }
+
+    @Test
+    fun `Password reset confirmation fails, state should stay in PasswordResetConfirm`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.resetPassword(any()) } returns Success(
+            AuthResetPasswordResult(
+                true,
+                AuthNextResetPasswordStep(AuthResetPasswordStep.CONFIRM_RESET_PASSWORD_WITH_CODE, emptyMap(), null)
+            )
+        )
+
+        coEvery { authProvider.confirmResetPassword(any(), any(),any())} returns Error(
+            mockk<UnknownException> {
+                every { cause } returns
+                        mockk<HttpException> {
+                            every { cause } returns mockk<UnknownHostException>()
+                        }
+            }
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
+
+        viewModel.resetPassword("username")
+        viewModel.confirmResetPassword("username", "password", "code")
+        viewModel.currentStep shouldBe AuthenticatorStep.PasswordResetConfirm
+    }
+
+    @Test
+    fun `Password reset confirmation succeeds, sign in fails, state should be sign in`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.resetPassword(any()) } returns Success(
+            AuthResetPasswordResult(
+                true,
+                AuthNextResetPasswordStep(AuthResetPasswordStep.CONFIRM_RESET_PASSWORD_WITH_CODE, emptyMap(), null)
+            )
+        )
+
+        coEvery { authProvider.confirmResetPassword(any(), any(),any())} returns Success(Unit)
+        coEvery { authProvider.signIn(any(), any()) } returns Error(
+            mockk<UnknownException> {
+                every { cause } returns
+                        mockk<HttpException> {
+                            every { cause } returns mockk<UnknownHostException>()
+                        }
+            }
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
+
+        viewModel.resetPassword("username")
+        viewModel.confirmResetPassword("username", "password", "code")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignIn
+    }
 //endregion
 //region helpers
     private val AuthenticatorViewModel.currentStep: AuthenticatorStep

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -352,6 +352,21 @@ class AuthenticatorViewModelTest {
         viewModel.currentStep shouldBe AuthenticatorStep.SignIn
     }
 
+    @Test
+    fun `Sign in with temporary password requires password reset`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
+            mockSignInResult(
+                signInStep = AuthSignInStep.RESET_PASSWORD
+            )
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.signIn("username", "password")
+        viewModel.currentStep shouldBe AuthenticatorStep.PasswordReset
+    }
+
 //endregion
 //region helpers
     private val AuthenticatorViewModel.currentStep: AuthenticatorStep

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -393,10 +393,9 @@ class AuthenticatorViewModelTest {
         coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
         coEvery { authProvider.resetPassword(any()) } returns Error(
             mockk<UnknownException> {
-                every { cause } returns
-                        mockk<HttpException> {
-                            every { cause } returns mockk<UnknownHostException>()
-                        }
+                every { cause } returns mockk<HttpException> {
+                    every { cause } returns mockk<UnknownHostException>()
+                }
             }
         )
         viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
@@ -415,7 +414,7 @@ class AuthenticatorViewModelTest {
             )
         )
 
-        coEvery { authProvider.confirmResetPassword(any(), any(),any())} returns Success(Unit)
+        coEvery { authProvider.confirmResetPassword(any(), any(), any()) } returns Success(Unit)
         coEvery { authProvider.signIn(any(), any()) } returns Success(mockSignInResult())
 
         viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.PasswordReset))
@@ -435,12 +434,11 @@ class AuthenticatorViewModelTest {
             )
         )
 
-        coEvery { authProvider.confirmResetPassword(any(), any(),any())} returns Error(
+        coEvery { authProvider.confirmResetPassword(any(), any(), any()) } returns Error(
             mockk<UnknownException> {
-                every { cause } returns
-                        mockk<HttpException> {
-                            every { cause } returns mockk<UnknownHostException>()
-                        }
+                every { cause } returns mockk<HttpException> {
+                    every { cause } returns mockk<UnknownHostException>()
+                }
             }
         )
 
@@ -461,13 +459,12 @@ class AuthenticatorViewModelTest {
             )
         )
 
-        coEvery { authProvider.confirmResetPassword(any(), any(),any())} returns Success(Unit)
+        coEvery { authProvider.confirmResetPassword(any(), any(), any()) } returns Success(Unit)
         coEvery { authProvider.signIn(any(), any()) } returns Error(
             mockk<UnknownException> {
-                every { cause } returns
-                        mockk<HttpException> {
-                            every { cause } returns mockk<UnknownHostException>()
-                        }
+                every { cause } returns mockk<HttpException> {
+                    every { cause } returns mockk<UnknownHostException>()
+                }
             }
         )
 


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-ui-android/issues/160
*Description of changes:*
Update password reset to automatically sign in after password reset successfully completes.  This matches with current behavior in [Amplify Swift](https://github.com/aws-amplify/amplify-ui-swift-authenticator/blob/main/Sources/Authenticator/States/ConfirmResetPasswordState.swift#L60-L75)

*How did you test these changes?*
* Manually tested on simulator to ensure that password reset automatically signs user in on completion.  
* Manually tested use case when a user signs in with a temporary password is prompted with password reset and workflow works as expected.  
* Added a unit test for the sign case of when password reset is required due to temporary password requiring reset.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
