### PR TITLE
chore: authenticator release to include all scopes (temporary)

### DIFF
--- a/scripts/fastlane/Fastfile
+++ b/scripts/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :android do |options|
           component_name: "Authenticator",
           top_level_docs_to_update: ["#{project_root}/README.md"],
           sample_build_files_to_update: ["#{project_root}/samples/authenticator/build.gradle"],
-          changelog_include_scopes: ["authenticator", "Authenticator", "all"],
+          changelog_include_scopes: [],
           changelog_ignore_scopes: ["liveness", "Liveness"]
         }
       ]


### PR DESCRIPTION
- [ ] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
This change is to enable the release PR workflow to pick up the commit for release, without the "authenticator" scope in the commit message name. We will revert this change in the script after the release.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
