### PR TITLE
feat(liveness): Use backend-provided values for some FaceDectector values

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ml/FaceDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ml/FaceDetector.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.ui.liveness.ml
 import android.content.Context
 import android.graphics.RectF
 import androidx.annotation.VisibleForTesting
+import com.amplifyframework.predictions.aws.models.FaceTargetChallenge
 import com.amplifyframework.predictions.aws.models.FaceTargetMatchingParameters
 import com.amplifyframework.ui.liveness.R
 import com.amplifyframework.ui.liveness.camera.LivenessCoordinator.Companion.TARGET_HEIGHT
@@ -42,10 +43,12 @@ internal class FaceDetector(private val livenessState: LivenessState) {
         outputScores: Array<Array<FloatArray>>
     ): List<Detection> {
         val detections = mutableListOf<Detection>()
+        val faceTargetChallenge = livenessState.faceTargetChallenge ?: return emptyList()
         for (i in 0 until NUM_BOXES) {
             var score = outputScores[0][i][0]
             score = computeSigmoid(score)
-            if (score < MIN_SCORE_THRESHOLD) {
+
+            if (score < faceTargetChallenge.faceTargetMatching.faceDetectionThreshold) {
                 continue
             }
 
@@ -159,6 +162,7 @@ internal class FaceDetector(private val livenessState: LivenessState) {
                     scaledMouth,
                     scaledLeftEar,
                     scaledRightEar,
+                    faceTargetChallenge.faceTargetMatching.targetHeightWidthRatio
                 )
             renormalizedDetections.add(
                 Detection(
@@ -183,13 +187,14 @@ internal class FaceDetector(private val livenessState: LivenessState) {
         nose: Landmark,
         mouth: Landmark,
         leftEar: Landmark,
-        rightEar: Landmark
+        rightEar: Landmark,
+        heightWidthRatio: Float
     ): RectF {
         val pupilDistance = calculatePupilDistance(leftEye, rightEye)
         val faceHeight = calculateFaceHeight(leftEye, rightEye, mouth)
 
         val ow = (ALPHA * pupilDistance + GAMMA * faceHeight) / 2
-        val oh = GOLDEN_RATIO * ow
+        val oh = heightWidthRatio * ow
 
         val eyeCenterX = (leftEye.x + rightEye.x) / 2
         val eyeCenterY = (leftEye.y + rightEye.y) / 2
@@ -450,7 +455,6 @@ internal class FaceDetector(private val livenessState: LivenessState) {
 
     companion object {
         private const val MIN_SUPPRESSION_THRESHOLD = 0.3f
-        private const val MIN_SCORE_THRESHOLD = 0.7f
         private val strides = listOf(8, 16, 16, 16)
         private const val ASPECT_RATIOS_SIZE = 1
         private const val MIN_SCALE = 0.1484375f
@@ -459,7 +463,6 @@ internal class FaceDetector(private val livenessState: LivenessState) {
         private const val ANCHOR_OFFSET_Y = 0.5f
         private const val INPUT_SIZE_HEIGHT = 128
         private const val INPUT_SIZE_WIDTH = 128
-        private const val GOLDEN_RATIO = 1.618f
         private const val ALPHA = 2.0f
         private const val GAMMA = 1.8f
         const val X_SCALE = 128f
@@ -479,7 +482,6 @@ internal class FaceDetector(private val livenessState: LivenessState) {
          * 14, 15 - right eye tragion
          */
         const val NUM_COORDS = 16
-        const val INITIAL_FACE_DISTANCE_THRESHOLD = 0.32f
 
         fun loadModel(context: Context): Interpreter {
             val modelFileDescriptor =

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
@@ -222,7 +222,7 @@ internal data class LivenessState(
                 leftEye, rightEye, mouth,
                 LivenessCoordinator.TARGET_WIDTH, LivenessCoordinator.TARGET_HEIGHT
             )
-            if (faceDistance >= FaceDetector.INITIAL_FACE_DISTANCE_THRESHOLD) {
+            if (faceDistance >= faceTargetChallenge!!.faceTargetMatching.faceDistanceThresholdMin) {
                 livenessCheckState =
                     LivenessCheckState.Initial.withMoveFaceFurtherAwayMessage()
             } else {

--- a/liveness/src/test/java/com/amplifyframework/ui/liveness/ml/FaceDetectorTest.kt
+++ b/liveness/src/test/java/com/amplifyframework/ui/liveness/ml/FaceDetectorTest.kt
@@ -37,8 +37,7 @@ internal class FaceDetectorTest {
     private val mouth = Landmark(0.5062596f, 0.68926525f)
     private val leftEar = Landmark(0.78989476f, 0.5973732f)
     private val rightEar = Landmark(0.16585289f, 0.5668279f)
-    private val width = 0.65490234f
-    private val height = 0.49117205f
+    private val heightWidthRatio = 1.618f
 
     @Before
     fun setup() {
@@ -68,7 +67,8 @@ internal class FaceDetectorTest {
             nose,
             mouth,
             leftEar,
-            rightEar
+            rightEar,
+            heightWidthRatio
         )
 
         // then


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
N/A

*Description of changes:*
This is a follow up to https://github.com/aws-amplify/amplify-android/pull/2883 where that PR starts passing server-provided values to the client, this removes the hard coded values to use those server-provided values.

*How did you test these changes?*
"Hardcoded" different values from the Amplify library to see them reflected on the Liveness UI Component

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
