### PR TITLE
chore(auth): refractor handleSignedIn method in AuthenticatorViewModel

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -582,7 +582,6 @@ internal class AuthenticatorViewModel(
                     logger.error(result.error.toString())
                     logger.error("Current signed in user session has expired, signing out.")
                     signOut()
-                    moveTo(AuthenticatorStep.SignIn)
                 } else {
                     handleGeneralFailure(result.error)
                 }

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -133,7 +133,7 @@ class AuthenticatorViewModelTest {
     }
 
     @Test
-    fun `getCurrentUser error with session expired exception during start results in SignIn state`() = runTest {
+    fun `getCurrentUser error with session expired exception during start results in being signed out`() = runTest {
         coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = true))
         coEvery { authProvider.getCurrentUser() } returns AmplifyResult.Error(SessionExpiredException())
 
@@ -143,8 +143,8 @@ class AuthenticatorViewModelTest {
         coVerify(exactly = 1) {
             authProvider.fetchAuthSession()
             authProvider.getCurrentUser()
+            authProvider.signOut()
         }
-        viewModel.currentStep shouldBe AuthenticatorStep.SignIn
     }
 
     @Test


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:* [https://github.com/aws-amplify/amplify-ui-android/issues/189](url)

*Description of changes:*
instead of "manually" _moveTo_ SignIn state after signing out, we could listen to HubEvents: _AuthChannelEventName.SIGNED_OUT_, which was implemented in _start() method of AuthenticatorViewModel.kt_.

*How did you test these changes?*
(Please add a line here how the changes were tested)
Instead of testing the resulting state (which should be SignIn), we just need to make sure that _signOut()_ is being called when _getCurrentUser_ errors with _SessionExpiredException_ during start

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
