### PR TITLE
chore(auth): Completed unit tests for AuthenticatorViewModel's signIn region

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -582,7 +582,6 @@ internal class AuthenticatorViewModel(
                     logger.error(result.error.toString())
                     logger.error("Current signed in user session has expired, signing out.")
                     signOut()
-                    moveTo(AuthenticatorStep.SignIn)
                 } else {
                     handleGeneralFailure(result.error)
                 }

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -133,7 +133,7 @@ class AuthenticatorViewModelTest {
     }
 
     @Test
-    fun `getCurrentUser error with session expired exception during start results in SignIn state`() = runTest {
+    fun `getCurrentUser error with session expired exception during start results in being signed out`() = runTest {
         coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = true))
         coEvery { authProvider.getCurrentUser() } returns AmplifyResult.Error(SessionExpiredException())
 
@@ -143,8 +143,8 @@ class AuthenticatorViewModelTest {
         coVerify(exactly = 1) {
             authProvider.fetchAuthSession()
             authProvider.getCurrentUser()
+            authProvider.signOut()
         }
-        viewModel.currentStep shouldBe AuthenticatorStep.SignIn
     }
 
     @Test

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -260,6 +260,34 @@ class AuthenticatorViewModelTest {
     }
 
     @Test
+    fun `Confirm SignUp next step, get error from resendSignUpCode, stays in SignIn screen`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_UP)
+        )
+        coEvery { authProvider.resendSignUpCode(any()) } returns AmplifyResult.Error(mockAuthException())
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.signIn("username", "password")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignIn
+    }
+
+    @Test
+    fun `Confirm SignUp next step shows the SignUpConfirm screen`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_UP)
+        )
+        coEvery { authProvider.resendSignUpCode(any()) } returns Success(mockk())
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.signIn("username", "password")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignUpConfirm
+    }
+
+    @Test
     fun `MFA selection next step shows error if allowedMFATypes is null`() = runTest {
         coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
         coEvery { authProvider.signIn(any(), any()) } returns Success(

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -221,6 +221,45 @@ class AuthenticatorViewModelTest {
     }
 
     @Test
+    fun `SMS MFA Code next step shows the SignInConfirmMfa screen`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE)
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.signIn("username", "password")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignInConfirmMfa
+    }
+
+    @Test
+    fun `Custom Challenge next step shows the SignInConfirmCustomAuth screen`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE)
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.signIn("username", "password")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignInConfirmCustomAuth
+    }
+
+    @Test
+    fun `New Password next step shows the SignInConfirmNewPassword screen`() = runTest {
+        coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
+        coEvery { authProvider.signIn(any(), any()) } returns Success(
+            mockSignInResult(signInStep = AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD)
+        )
+
+        viewModel.start(mockAuthenticatorConfiguration(initialStep = AuthenticatorStep.SignIn))
+
+        viewModel.signIn("username", "password")
+        viewModel.currentStep shouldBe AuthenticatorStep.SignInConfirmNewPassword
+    }
+
+    @Test
     fun `MFA selection next step shows error if allowedMFATypes is null`() = runTest {
         coEvery { authProvider.fetchAuthSession() } returns Success(mockAuthSession(isSignedIn = false))
         coEvery { authProvider.signIn(any(), any()) } returns Success(


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
Added missing test cases in _AuthenticatorViewModelTest.kt_ for when _AuthSignInStep_ is one of the following:
- _CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE_
- _CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE_
- _CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_
- _CONFIRM_SIGN_UP_

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
