### PR TITLE
fix(liveness): Detect failed camera opening

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/LivenessCoordinator.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/LivenessCoordinator.kt
@@ -50,6 +50,7 @@ import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal typealias OnMuxedSegment = (bytes: ByteArray, timestamp: Long) -> Unit
@@ -137,6 +138,16 @@ internal class LivenessCoordinator(
     private var disconnectEventReceived = false
 
     init {
+        MainScope().launch {
+            delay(5_000)
+            if (!previewTextureView.hasReceivedUpdate) {
+                val faceLivenessException = FaceLivenessDetectionException(
+                    "The camera failed to open within the allowed time limit.",
+                    "Ensure the camera is available to use and that no other apps are using it."
+                )
+                processSessionError(faceLivenessException, true)
+            }
+        }
         MainScope().launch {
             getCameraProvider(context).apply {
                 if (lifecycleOwner.lifecycle.currentState != Lifecycle.State.DESTROYED) {

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/PreviewTextureView.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/PreviewTextureView.kt
@@ -31,6 +31,7 @@ internal class PreviewTextureView(
 ) : TextureView(context) {
 
     private var surface: Surface? = null
+    internal var hasReceivedUpdate = false
 
     init {
         surfaceTextureListener = object : SurfaceTextureListener {
@@ -48,7 +49,11 @@ internal class PreviewTextureView(
                 }
             }
 
-            override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {}
+            override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {
+                if (!hasReceivedUpdate) {
+                    hasReceivedUpdate = true
+                }
+            }
 
             override fun onSurfaceTextureSizeChanged(
                 surfaceTexture: SurfaceTexture,


### PR DESCRIPTION
The change monitors the camera binding and throws an error if no camera frames are detected within 5 seconds of an attempted launch.

- [ ] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
