### PR TITLE
fix(authenticator): Upgrade Amplify dependency to 2.27.0

### DIFF
--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -229,6 +229,15 @@ internal class AuthenticatorViewModel(
                 moveTo(newState)
             }
             AuthSignUpStep.DONE -> handleSignedUp(username, password)
+            else -> {
+                // Generic error for any other next steps that may be added in the future
+                val exception = AuthException(
+                    "Unsupported next step ${result.nextStep.signUpStep}.",
+                    "Authenticator does not support this Authentication flow, disable it to use Authenticator."
+                )
+                logger.error("Unsupported next step ${result.nextStep.signUpStep}", exception)
+                sendMessage(UnknownErrorMessage(exception))
+            }
         }
     }
 

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
@@ -17,6 +17,7 @@ package com.amplifyframework.ui.authenticator
 
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.AuthFactorType
 import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
@@ -71,19 +72,12 @@ internal fun mockAuthException(
     cause = cause
 )
 
-internal fun mockAuthSession(
-    isSignedIn: Boolean = false
-) = AuthSession(isSignedIn)
+internal fun mockAuthSession(isSignedIn: Boolean = false) = AuthSession(isSignedIn)
 
-internal fun mockAuthUser(
-    userId: String = "userId",
-    username: String = "username"
-) = AuthUser(userId, username)
+internal fun mockAuthUser(userId: String = "userId", username: String = "username") = AuthUser(userId, username)
 
-internal fun mockSignInResult(
-    isSignedIn: Boolean = true,
-    nextSignInStep: AuthNextSignInStep = mockNextSignInStep()
-) = AuthSignInResult(isSignedIn, nextSignInStep)
+internal fun mockSignInResult(isSignedIn: Boolean = true, nextSignInStep: AuthNextSignInStep = mockNextSignInStep()) =
+    AuthSignInResult(isSignedIn, nextSignInStep)
 
 internal fun mockSignInResult(
     signInStep: AuthSignInStep = AuthSignInStep.DONE,
@@ -107,14 +101,18 @@ internal fun mockNextSignInStep(
     additionalInfo: Map<String, String> = emptyMap(),
     codeDeliveryDetails: AuthCodeDeliveryDetails? = null,
     totpSetupDetails: TOTPSetupDetails? = null,
-    allowedMFATypes: Set<MFAType>? = null
-) = AuthNextSignInStep(signInStep, additionalInfo, codeDeliveryDetails, totpSetupDetails, allowedMFATypes)
+    allowedMFATypes: Set<MFAType>? = null,
+    availableFactors: Set<AuthFactorType>? = null
+) = AuthNextSignInStep(
+    signInStep,
+    additionalInfo,
+    codeDeliveryDetails,
+    totpSetupDetails,
+    allowedMFATypes,
+    availableFactors
+)
 
-internal fun mockUserAttributes(
-    vararg attribute: Pair<AuthUserAttributeKey, String>
-) = attribute.map { AuthUserAttribute(it.first, it.second) }
+internal fun mockUserAttributes(vararg attribute: Pair<AuthUserAttributeKey, String>) =
+    attribute.map { AuthUserAttribute(it.first, it.second) }
 
-internal fun mockUser(
-    userId: String = "userId",
-    username: String = "username"
-) = AuthUser(userId, username)
+internal fun mockUser(userId: String = "userId", username: String = "username") = AuthUser(userId, username)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.1.4"
-amplify = "2.24.0"
+amplify = "2.27.0"
 binary-compatibility = "0.14.0"
 cameraX = "1.2.0"
 compose = "1.5.4"

--- a/samples/authenticator/app/build.gradle
+++ b/samples/authenticator/app/build.gradle
@@ -35,7 +35,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.3'
+        kotlinCompilerExtensionVersion "1.5.3"
     }
     packagingOptions {
         resources {

--- a/samples/authenticator/build.gradle
+++ b/samples/authenticator/build.gradle
@@ -10,5 +10,5 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.1.4' apply false
     id 'com.android.library' version '8.1.4' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.10' apply false
 }


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*
#203 

*Description of changes:*
Upgrade Amplify to 2.27.0 to get fix for `getCurrentUser` failing while offline with expired access tokens.

*How did you test these changes?*
- Reproduced bug

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
