### PR TITLE
fix(authenticator): Add support for auto-sign-in

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
 [*.{kt,kts}]
 #this is to match java checkstyle
 max_line_length=120
+ktlint_code_style=android_studio

--- a/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
+++ b/authenticator/src/main/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModel.kt
@@ -90,10 +90,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.VisibleForTesting
 
-internal class AuthenticatorViewModel(
-    application: Application,
-    private val authProvider: AuthProvider
-) : AndroidViewModel(application) {
+internal class AuthenticatorViewModel(application: Application, private val authProvider: AuthProvider) :
+    AndroidViewModel(application) {
 
     // Constructor for compose viewModels provider
     constructor(application: Application) : this(application, RealAuthProvider())
@@ -185,7 +183,8 @@ internal class AuthenticatorViewModel(
 
     //region SignUp
 
-    private suspend fun signUp(username: String, password: String, attributes: List<AuthUserAttribute>) {
+    @VisibleForTesting
+    suspend fun signUp(username: String, password: String, attributes: List<AuthUserAttribute>) {
         viewModelScope.launch {
             val options = AuthSignUpOptions.builder().userAttributes(attributes).build()
 
@@ -229,6 +228,7 @@ internal class AuthenticatorViewModel(
                 moveTo(newState)
             }
             AuthSignUpStep.DONE -> handleSignedUp(username, password)
+            AuthSignUpStep.COMPLETE_AUTO_SIGN_IN -> handleAutoSignIn(username, password)
             else -> {
                 // Generic error for any other next steps that may be added in the future
                 val exception = AuthException(
@@ -238,6 +238,18 @@ internal class AuthenticatorViewModel(
                 logger.error("Unsupported next step ${result.nextStep.signUpStep}", exception)
                 sendMessage(UnknownErrorMessage(exception))
             }
+        }
+    }
+
+    private suspend fun handleAutoSignIn(username: String, password: String) {
+        when (val result = authProvider.autoSignIn()) {
+            is AmplifyResult.Error -> {
+                // If auto sign in fails then proceed with manually trying to sign in the user. If this also fails the
+                // user will end up back on the sign in screen.
+                logger.warn("Unable to complete auto-signIn")
+                handleSignedUp(username, password)
+            }
+            is AmplifyResult.Success -> handleSignInSuccess(username, password, result.data)
         }
     }
 
@@ -355,10 +367,7 @@ internal class AuthenticatorViewModel(
         )
     }
 
-    private suspend fun handleEmailMfaSetupRequired(
-        username: String,
-        password: String
-    ) {
+    private suspend fun handleEmailMfaSetupRequired(username: String, password: String) {
         moveTo(
             stateFactory.newSignInContinueWithEmailSetupState(
                 onSubmit = { mfaType -> confirmSignIn(username, password, mfaType) }
@@ -366,11 +375,7 @@ internal class AuthenticatorViewModel(
         )
     }
 
-    private suspend fun handleMfaSelectionRequired(
-        username: String,
-        password: String,
-        allowedMfaTypes: Set<MFAType>?
-    ) {
+    private suspend fun handleMfaSelectionRequired(username: String, password: String, allowedMfaTypes: Set<MFAType>?) {
         if (allowedMfaTypes.isNullOrEmpty()) {
             handleGeneralFailure(AuthException("Missing allowedMfaTypes", "Please open a bug with Amplify"))
             return
@@ -492,10 +497,7 @@ internal class AuthenticatorViewModel(
         }.join()
     }
 
-    private suspend fun handleResetPasswordSuccess(
-        username: String,
-        result: AuthResetPasswordResult
-    ) {
+    private suspend fun handleResetPasswordSuccess(username: String, result: AuthResetPasswordResult) {
         when (result.nextStep.resetPasswordStep) {
             AuthResetPasswordStep.DONE -> handlePasswordResetComplete()
             AuthResetPasswordStep.CONFIRM_RESET_PASSWORD_WITH_CODE -> {

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/AuthenticatorViewModelTest.kt
@@ -27,6 +27,7 @@ import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.step.AuthNextResetPasswordStep
 import com.amplifyframework.auth.result.step.AuthResetPasswordStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
 import com.amplifyframework.ui.authenticator.auth.VerificationMechanism
 import com.amplifyframework.ui.authenticator.enums.AuthenticatorStep
 import com.amplifyframework.ui.authenticator.util.AmplifyResult
@@ -438,6 +439,22 @@ class AuthenticatorViewModelTest {
 
         // Assert step does not change
         viewModel.currentStep shouldBe AuthenticatorStep.SignIn
+    }
+
+//endregion
+//region sign up tests
+
+    @Test
+    fun `user can autoSignIn after sign up`() = runTest {
+        val result = mockSignUpResult(nextStep = mockNextSignUpStep(signUpStep = AuthSignUpStep.COMPLETE_AUTO_SIGN_IN))
+        coEvery { authProvider.signUp("username", "password", any()) } returns Success(result)
+        coEvery { authProvider.autoSignIn() } returns Success(mockSignInResult())
+
+        viewModel.start(mockAuthenticatorConfiguration())
+        viewModel.signUp("username", "password", emptyList())
+        advanceUntilIdle()
+
+        viewModel.currentStep shouldBe AuthenticatorStep.SignedIn
     }
 
 //endregion

--- a/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
+++ b/authenticator/src/test/java/com/amplifyframework/ui/authenticator/MockAuthenticatorData.kt
@@ -25,8 +25,11 @@ import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.result.AuthSignInResult
+import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.step.AuthNextSignInStep
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
 import com.amplifyframework.ui.authenticator.auth.AmplifyAuthConfiguration
 import com.amplifyframework.ui.authenticator.auth.PasswordCriteria
 import com.amplifyframework.ui.authenticator.auth.SignInMethod
@@ -110,6 +113,25 @@ internal fun mockNextSignInStep(
     totpSetupDetails,
     allowedMFATypes,
     availableFactors
+)
+
+internal fun mockSignUpResult(
+    nextStep: AuthNextSignUpStep,
+    userId: String = "userId"
+) = AuthSignUpResult(
+    nextStep.signUpStep != AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
+    nextStep,
+    userId
+)
+
+internal fun mockNextSignUpStep(
+    signUpStep: AuthSignUpStep = AuthSignUpStep.DONE,
+    additionalInfo: Map<String, String> = emptyMap(),
+    codeDeliveryDetails: AuthCodeDeliveryDetails? = null
+) = AuthNextSignUpStep(
+    signUpStep,
+    additionalInfo,
+    codeDeliveryDetails
 )
 
 internal fun mockUserAttributes(vararg attribute: Pair<AuthUserAttributeKey, String>) =


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
This change fixes an issue where Authenticator would show an error after signup (requiring an app restart) if `USER_AUTH` has been enabled for the user pool, even if there is no intention to use that flow for sign in.

This is because having `USER_AUTH` enabled allows cognito to return the next sign up step of `COMPLETE_AUTO_SIGN_IN` which Authenticator could not handle. This PR adds support for this result.

*How did you test these changes?*
- Unit tests
- Test app

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
