### PR TITLE
fix(liveness): Prevent crashing if there's an exception thrown by the SurfaceTexture

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/OpenGLRenderer.java
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/camera/OpenGLRenderer.java
@@ -383,8 +383,12 @@ final class OpenGLRenderer {
                             Log.d(TAG, "setOnFrameAvailableListener");
                         }
                         makeCurrent(mNativeContext);
-                        surfaceTexture.updateTexImage();
-                        renderLatest();
+                        try {
+                            surfaceTexture.updateTexImage();
+                            renderLatest();
+                        } catch(Exception e) {
+                            Log.e(TAG, "Received an exception while updating texture image", e);
+                        }
                     }
                 },
                 mExecutor.getHandler());


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:* N/A

*Description of changes:* 
We've reports that some old devices were crashing due to this line throwing a Runtime/IllegalStateException. Instead of crashing, we will now silently handle the exception and let the rest of the flow fail back to the app flow. We can now expect the following behaviors:

If the exception happens at the first frame, it'll fail fast because there is existing logic that says "if the camera preview hasn't initialized for the first 5 seconds, throw a camera failed to open exception." Alternatively, if the exception happens after the camera has initialized, the liveness check will eventually time out with an exception thrown with the cause being "Stream idle timeoutExceeded." Both of which are reasonable messaging to the developer.

*How did you test these changes?*
Had to manually test this since my test devices couldn't reproduce the core issue but were able to manually force the above edge cases to see how the SDK handles it.


*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
