### PR TITLE
fix(liveness): Remove challenge options from the FaceLivenessDetector key

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/ui/FaceLivenessDetector.kt
@@ -114,7 +114,7 @@ fun FaceLivenessDetector(
     challengeOptions: ChallengeOptions = ChallengeOptions(),
 ) {
     val scope = rememberCoroutineScope()
-    val key = DetectorStateKey(sessionId, region, credentialsProvider, challengeOptions)
+    val key = DetectorStateKey(sessionId, region, credentialsProvider)
     var isFinished by remember(key) { mutableStateOf(false) }
     val currentOnComplete by rememberUpdatedState(onComplete)
     val currentOnError by rememberUpdatedState(onError)
@@ -446,8 +446,7 @@ internal fun ChallengeView(
 internal data class DetectorStateKey(
     val sessionId: String,
     val region: String,
-    val credentialsProvider: AWSCredentialsProvider<AWSCredentials>?,
-    val challengeOptions: ChallengeOptions
+    val credentialsProvider: AWSCredentialsProvider<AWSCredentials>?
 )
 
 data class ChallengeOptions(


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:* N/A

*Description of changes:* After a callout from Tyler and some additional testing, found that having the challenge option as part of the remembered state for the Composable will break since when the view is rendered, the session ID is considered started and thus can't be reused which is what happens when the Composable gets torn down and restarted. Instead, will have to add a callout to the docs change that developers will need to create a new session ID if they wish to change the camera orientation "on the fly"

*How did you test these changes?* Tested by attemping to "swap" camera options at runtime at the start view as well as while the liveness check is happening. Before this fix, the Composable would restart and Rekognition would return an exception saying the session is no longer valid. After this fix, attempting to "swap" the option doesn't do anything.

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
