### PR TITLE
fix(liveness): 16kb Page Support for Liveness

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,12 +20,11 @@ kover = "0.9.1"
 ktlint = "11.0.0"
 licensee = "1.7.0"
 lifecycle = "2.4.0"
+litert = "1.4.0"
 mockk = "1.13.4"
 robolectric = "4.14.1"
 roborazzi = "1.43.1"
 serialization = "1.3.3"
-tensorflow = "2.0.0"
-tensorflow-support = "0.3.0"
 turbine = "1.0.0"
 zxing = "3.5.2"
 
@@ -64,8 +63,8 @@ kotlin-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializat
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 
 # TensorFlow
-tensorflow = { module = "org.tensorflow:tensorflow-lite", version.ref = "tensorflow" }
-tensorflow-support = {module = "org.tensorflow:tensorflow-lite-support", version.ref = "tensorflow-support" }
+litert = { module = "com.google.ai.edge.litert:litert", version.ref = "litert" }
+litert-support = { module = "com.google.ai.edge.litert:litert-support", version.ref = "litert" }
 
 # Other
 zxing = { module = "com.google.zxing:core", version.ref = "zxing" }

--- a/liveness/build.gradle.kts
+++ b/liveness/build.gradle.kts
@@ -9,7 +9,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags += "-std=c++17"
-                arguments += "-DCMAKE_VERBOSE_MAKEFILE=ON"
+                arguments += listOf("-DCMAKE_VERBOSE_MAKEFILE=ON", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
             }
         }
         buildConfigField(
@@ -58,8 +58,8 @@ dependencies {
 
     implementation(libs.kotlin.serialization.json)
 
-    implementation(libs.tensorflow)
-    implementation(libs.tensorflow.support)
+    implementation(libs.litert)
+    implementation(libs.litert.support)
 
     coreLibraryDesugaring(libs.android.desugar)
 


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:* #161

*Description of changes:*
Updates Liveness to work with 16kb page size

*How did you test these changes?*
- Verified Liveness session can run on device with 16kb page size enabled.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
