### PR TITLE
chore: Remember your theme selection in the sample app

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ agp = "8.11.1"
 amplify = "2.29.2"
 appcompat = "1.6.1"
 androidx-core = "1.9.0"
+androidx-datastore = "1.1.7"
 androidx-junit = "1.1.4"
 androidx-activity = "1.6.1"
 androidx-navigation = "2.5.3"
@@ -82,6 +83,9 @@ test-robolectric = { module = "org.robolectric:robolectric", version.ref = "robo
 test-roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
 test-roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version.ref = "roborazzi" }
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+
+# Dependencies for sample apps
+samples-androidx-datastore-prefs = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 
 # Dependencies for convention plugins
 plugin-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/samples/authenticator/app/.gitignore
+++ b/samples/authenticator/app/.gitignore
@@ -1,4 +1,4 @@
 /build
 /buildNative
 **/awsconfiguration.json
-**/amplifyconfiguration.json
+**/amplifyconfiguration**.json

--- a/samples/authenticator/app/build.gradle.kts
+++ b/samples/authenticator/app/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.bundles.compose)
     implementation(libs.androidx.lifecycle)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.samples.androidx.datastore.prefs)
 
     coreLibraryDesugaring(libs.android.desugar)
 }

--- a/samples/authenticator/app/src/main/java/com/amplifyframework/ui/sample/authenticator/ThemeSelector.kt
+++ b/samples/authenticator/app/src/main/java/com/amplifyframework/ui/sample/authenticator/ThemeSelector.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.ui.sample.authenticator
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -30,7 +31,8 @@ import com.amplifyframework.ui.sample.authenticator.theme.default.AppTheme
 
 enum class SupportedTheme {
     Default,
-    Amplify
+    Amplify,
+    Dynamic
 }
 
 @Composable
@@ -42,7 +44,8 @@ fun ThemeSelector(
     onChangeDarkMode: (Boolean) -> Unit
 ) {
     Column(modifier = modifier) {
-        SupportedTheme.values().forEach { theme ->
+        Text("Theme", style = MaterialTheme.typography.titleMedium)
+        SupportedTheme.entries.forEach { theme ->
             Row(verticalAlignment = Alignment.CenterVertically) {
                 RadioButton(selected = theme == currentTheme, onClick = { onChangeCurrentTheme(theme) })
                 Text(modifier = Modifier.padding(start = 8.dp), text = theme.name)
@@ -58,7 +61,8 @@ fun ThemeSelector(
 @Composable
 fun ApplyTheme(theme: SupportedTheme, darkMode: Boolean, content: @Composable () -> Unit) {
     when (theme) {
-        SupportedTheme.Default -> AppTheme(darkTheme = darkMode, content = content)
+        SupportedTheme.Default -> AppTheme(darkTheme = darkMode, dynamicColor = false, content = content)
         SupportedTheme.Amplify -> AmplifyTheme(useDarkTheme = darkMode, content = content)
+        SupportedTheme.Dynamic -> AppTheme(darkTheme = darkMode, dynamicColor = true, content = content)
     }
 }

--- a/samples/authenticator/app/src/main/java/com/amplifyframework/ui/sample/authenticator/data/ThemeDatastore.kt
+++ b/samples/authenticator/app/src/main/java/com/amplifyframework/ui/sample/authenticator/data/ThemeDatastore.kt
@@ -1,0 +1,43 @@
+package com.amplifyframework.ui.sample.authenticator.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.amplifyframework.ui.sample.authenticator.SupportedTheme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ThemeDatastore(context: Context) {
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "theme")
+
+    private val datastore = context.dataStore
+
+    private val darkModeKey = booleanPreferencesKey("darkMode")
+    private val themeKey = stringPreferencesKey("theme")
+
+    suspend fun saveTheme(theme: SupportedTheme) {
+        datastore.edit { settings ->
+            settings[themeKey] = theme.name
+        }
+    }
+
+    suspend fun saveDarkMode(darkMode: Boolean) {
+        datastore.edit { settings ->
+            settings[darkModeKey] = darkMode
+        }
+    }
+
+    val darkMode: Flow<Boolean> = datastore.data.map { settings ->
+        settings[darkModeKey] ?: false
+    }
+    val theme: Flow<SupportedTheme> = datastore.data.map { settings ->
+        val name = settings[themeKey] ?: SupportedTheme.Default.name
+        SupportedTheme.valueOf(name)
+    }
+
+}

--- a/samples/authenticator/app/src/main/java/com/amplifyframework/ui/sample/authenticator/theme/amplifytheme/Theme.kt
+++ b/samples/authenticator/app/src/main/java/com/amplifyframework/ui/sample/authenticator/theme/amplifytheme/Theme.kt
@@ -15,11 +15,16 @@
 
 package com.amplifyframework.ui.sample.authenticator.theme.amplifytheme
 
+import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.ViewCompat
 
 private val LightColors = lightColorScheme(
     primary = md_theme_light_primary,
@@ -82,14 +87,19 @@ private val DarkColors = darkColorScheme(
 )
 
 @Composable
-fun AmplifyTheme(
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable () -> Unit
-) {
+fun AmplifyTheme(useDarkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     val colors = if (!useDarkTheme) {
         LightColors
     } else {
         DarkColors
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            (view.context as Activity).window.statusBarColor = colors.primary.toArgb()
+            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = useDarkTheme
+        }
     }
 
     MaterialTheme(


### PR DESCRIPTION
- [x] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*
Save your theme selections across app restarts in the authenticator sample app. Also makes dynamic theme a separate option.

*How did you test these changes?*
Verified themes are remembered

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
