### PR TITLE
fix(liveness): Prevent challenge from restarting

### DIFF
--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
@@ -311,7 +311,6 @@ internal data class LivenessState(
     }
 
     fun onStartViewComplete() {
-        livenessCheckState = LivenessCheckState.Running()
         showingStartView = false
     }
 }

--- a/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
+++ b/liveness/src/main/java/com/amplifyframework/ui/liveness/state/LivenessState.kt
@@ -231,7 +231,7 @@ internal data class LivenessState(
             }
         }
 
-        if (readyForOval) {
+        if (readyForOval && initialFaceDistanceCheckPassed) {
             if (initialStreamFace == null) {
                 val face = InitialStreamFace(faceRect, System.currentTimeMillis())
                 onCaptureReady()


### PR DESCRIPTION
The challenge was starting even before the face was a proper distance away. Before the no-light PR, `readyForOval` was not set until the initial face distance check had passed. This corrects the previous behavior of no starting the challenge until the face is the correct distance away.

- [ ] PR conforms to [Pull Request](https://github.com/aws-amplify/amplify-ui-android/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(liveness): message`, `fix(authenticator): message`, `fix(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
